### PR TITLE
feat: Support inheriting labels from RisingWave to sub-resources

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -32,8 +32,9 @@ const (
 // =================================================
 
 const (
-	AnnotationRestartAt      = "risingwave/restart-at"
-	AnnotationPauseReconcile = "risingwave.risingwavelabs.com/pause-reconcile"
+	AnnotationRestartAt          = "risingwave/restart-at"
+	AnnotationPauseReconcile     = "risingwave.risingwavelabs.com/pause-reconcile"
+	AnnotationInheritLabelPrefix = "risingwave.risingwavelabs.com/inherit-label-prefix"
 )
 
 // =================================================

--- a/pkg/factory/risingwave_object_factory_test.go
+++ b/pkg/factory/risingwave_object_factory_test.go
@@ -1376,16 +1376,16 @@ func Test_RisingWaveObjectFactory_InheritLabels(t *testing.T) {
 
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
-			factory := &RisingWaveObjectFactory{risingwave: &risingwavev1alpha1.RisingWave{
+			factory := NewRisingWaveObjectFactory(&risingwavev1alpha1.RisingWave{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: tc.labels,
 					Annotations: map[string]string{
 						consts.AnnotationInheritLabelPrefix: tc.inheritPrefixValue,
 					},
 				},
-			}}
+			}, nil)
 
-			assert.Equal(t, tc.inheritedLabels, factory.inheritedLabels(), "inherited labels not match")
+			assert.Equal(t, tc.inheritedLabels, factory.getInheritedLabels(), "inherited labels not match")
 		})
 	}
 }


### PR DESCRIPTION
Signed-off-by: arkbriar <arkbriar@gmail.com>

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Some of the labels of RisingWave will be inherited, to sub-resources such as Service, ConfigMap, Deployment, StatefulSet, and the Pods controlled by the workload objects. The behavior is controlled with an annotation `risingwave.risingwavelabs.com/inherit-label-prefix`. The value of it should be a list of label prefixes separated by commas.
  - Note: label prefix should omit the slash. 

```yaml
metadata:
  name: risingwave-in-memory
  labels:
    risingwave.dev/user: abc123
  annotations:
    risingwave.risingwavelabs.com/inherit-label-prefix: risingwave.dev
```

NOTE: the Pods' labels are set by updating the pod template, so any change on the inherited labels would trigger a full upgrade of the Pods. Be careful!

## Checklist

- [x] I have written the necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
