### PR TITLE
use docker buildx build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ run-local: manifests generate fmt vet lint install-local
 	go run cmd/manager/manager.go -zap-time-encoding rfc3339
 
 e2e-test: generate-test-yaml vendor
-	docker build -f docker/Dockerfile --build-arg USE_VENDOR=true -t docker.io/risingwavelabs/risingwave-operator:dev . --output=type=docker
+	docker buildx build -f docker/Dockerfile --build-arg USE_VENDOR=true -t docker.io/risingwavelabs/risingwave-operator:dev . --load
 	e2e/e2e.sh
 
 e2e-plugin:
@@ -163,10 +163,10 @@ docker-cross-build-vendor: test buildx vendor
 	docker buildx build -f docker/Dockerfile --build-arg USE_VENDOR=true --platform=linux/amd64,linux/arm64 -t ${IMG} . --push
 
 docker-build: test ## Build docker image with the manager.
-	docker build -f docker/Dockerfile --build-arg USE_VENDOR=false -t ${IMG} . --output=type=docker
+	docker buildx build -f docker/Dockerfile --build-arg USE_VENDOR=false -t ${IMG} . --load
 
 docker-build-vendor: vendor test
-	docker build -f docker/Dockerfile --build-arg USE_VENDOR=true -t ${IMG} . --output=type=docker
+	docker buildx build -f docker/Dockerfile --build-arg USE_VENDOR=true -t ${IMG} . --load
 
 docker-push: ## Push docker image with the manager.
 	docker push ${IMG}


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Explicitly use `docker buildx build` instead of `docker build`, because `docker build` seems to have issue with `--load` parameter.


## Checklist

- [x] I have written the necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
