### PR TITLE
refactor: remove the default config

### DIFF
--- a/.cspell/misc.txt
+++ b/.cspell/misc.txt
@@ -36,3 +36,5 @@ risedev
 retryable
 yamlex
 risingwavelabs
+fallocate
+nums

--- a/pkg/factory/risingwave_object_factory.go
+++ b/pkg/factory/risingwave_object_factory.go
@@ -38,27 +38,8 @@ import (
 )
 
 const (
-	risingWaveConfigVolume   = "risingwave-config"
-	risingWaveConfigMapKey   = "risingwave.toml"
-	risingWaveConfigTemplate = `[ server ]
-heartbeat_interval = 1000
-
-[ streaming ]
-checkpoint_interval_ms = 100
-
-[ storage ]
-sstable_size_mb = 256
-block_size_kb = 16
-bloom_false_positive = 0.1
-share_buffers_sync_parallelism = 2
-shared_buffer_capacity_mb = 1024
-data_directory = "hummock_001"
-write_conflict_detection_enabled = true
-block_cache_capacity_mb = 256
-meta_cache_capacity_mb = 64
-disable_remote_compactor = false
-enable_local_spill = true
-local_object_store = "tempdisk"`
+	risingWaveConfigVolume = "risingwave-config"
+	risingWaveConfigMapKey = "risingwave.toml"
 
 	envMinIOUsername = "MINIO_USERNAME"
 	envMinIOPassword = "MINIO_PASSWORD"
@@ -542,7 +523,7 @@ func (f *RisingWaveObjectFactory) NewConfigConfigMap(val string) *corev1.ConfigM
 	risingwaveConfigConfigMap := &corev1.ConfigMap{
 		ObjectMeta: f.componentObjectMeta(consts.ComponentConfig, false), // not synced
 		Data: map[string]string{
-			risingWaveConfigMapKey: nonZeroOrDefault(val, risingWaveConfigTemplate),
+			risingWaveConfigMapKey: nonZeroOrDefault(val, ""),
 		},
 	}
 	return mustSetControllerReference(f.risingwave, risingwaveConfigConfigMap, f.scheme)

--- a/pkg/factory/risingwave_object_factory_test.go
+++ b/pkg/factory/risingwave_object_factory_test.go
@@ -411,7 +411,7 @@ func Test_RisingWaveObjectFactory_ConfigMaps(t *testing.T) {
 				}),
 				newObjectAssert(cm, "configmap-data-match", func(obj *corev1.ConfigMap) bool {
 					return mapEquals(obj.Data, map[string]string{
-						risingWaveConfigMapKey: lo.If(tc.configVal == "", risingWaveConfigTemplate).Else(tc.configVal),
+						risingWaveConfigMapKey: lo.If(tc.configVal == "", "").Else(tc.configVal),
 					})
 				}),
 			).Assert(t)


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- In the PR risingwavelabs/risingwave#4966, the config `checkpoint_interval_ms` is deprecated, so the previous default config is no longer compatible. I decided to remove the default config so that the kernel will read an empty file and use the inner default configs.
- This also fixes the E2E tests.

NOTE: RisingWave versions before that will not be able to start with a default config after this is merged.

## Checklist

- [x] I have written the necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
