### PR TITLE
chore(plugin): update the default operator version to v0.2.2

### DIFF
--- a/pkg/command/install/version/verison.go
+++ b/pkg/command/install/version/verison.go
@@ -25,7 +25,7 @@ import (
 const (
 	MinimumVersion = "v0.2.0"
 
-	DefaultVersion = "v0.2.0"
+	DefaultVersion = "v0.2.2"
 
 	LatestVersion = "latest" // TODO: need to convert latest to the version tag https://github.com/risingwavelabs/risingwave-operator/issues/201
 )


### PR DESCRIPTION
Signed-off-by: arkbriar <arkbriar@gmail.com>

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- As title. This should fix the plugin e2e.

## Checklist

- [x] I have written the necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
