### PR TITLE
ci(Mergify): configuration update

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -38,6 +38,8 @@ pull_request_rules:
       - "#changes-requested-reviews-by=0"
       - "check-pending!=unit-test"
       - "check-failure!=unit-test"
+      - "check-pending!=codecov/project"
+      - "check-failure!=codecov/project"
       - "check-pending!=e2e-test"
       - "check-failure!=e2e-test"
       - "check-pending!=build_docker_images"


### PR DESCRIPTION
This change has been made by @CAJan93 from Mergify config editor.

Automerge will not be possible if codecov detects coverage reduction.

Thanks for the `codecov` fix in https://github.com/risingwavelabs/risingwave-operator/pull/275 @xxchan 
CC @arkbriar 