### PR TITLE
fix: fix the default value of `-enable-open-kruise` option

### DIFF
--- a/cmd/manager/manager.go
+++ b/cmd/manager/manager.go
@@ -73,7 +73,7 @@ func main() {
 	opts := zap.Options{
 		Development: true,
 	}
-	flag.BoolVar(&enableOpenKruise, "enable-open-kruise", true, "Enabling this will allow openkruise to be available as an optional provider")
+	flag.BoolVar(&enableOpenKruise, "enable-open-kruise", false, "Enabling this will allow openkruise to be available as an optional provider")
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 


### PR DESCRIPTION
Signed-off-by: arkbriar <arkbriar@gmail.com>

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Set the value to false. Otherwise, the option is always enabled.

## Checklist

- [x] I have written the necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
