### PR TITLE
fix: use a pointer for the scaleview.spec.replicas to distinguish bet…

### DIFF
--- a/apis/risingwave/v1alpha1/risingwave_scale_view_types.go
+++ b/apis/risingwave/v1alpha1/risingwave_scale_view_types.go
@@ -65,7 +65,7 @@ type RisingWaveScaleViewSpec struct {
 	TargetRef RisingWaveScaleViewTargetRef `json:"targetRef,omitempty"`
 
 	// Desired replicas.
-	Replicas int32 `json:"replicas,omitempty"`
+	Replicas *int32 `json:"replicas,omitempty"`
 
 	// Serialized label selector. Would be set by the webhook.
 	LabelSelector string `json:"labelSelector,omitempty"`

--- a/apis/risingwave/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/risingwave/v1alpha1/zz_generated.deepcopy.go
@@ -846,6 +846,11 @@ func (in *RisingWaveScaleViewLockGroupLock) DeepCopy() *RisingWaveScaleViewLockG
 func (in *RisingWaveScaleViewSpec) DeepCopyInto(out *RisingWaveScaleViewSpec) {
 	*out = *in
 	out.TargetRef = in.TargetRef
+	if in.Replicas != nil {
+		in, out := &in.Replicas, &out.Replicas
+		*out = new(int32)
+		**out = **in
+	}
 	if in.ScalePolicy != nil {
 		in, out := &in.ScalePolicy, &out.ScalePolicy
 		*out = make([]RisingWaveScaleViewSpecScalePolicy, len(*in))

--- a/pkg/manager/risingwave_scale_view_controller_manager_impl_test.go
+++ b/pkg/manager/risingwave_scale_view_controller_manager_impl_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -77,7 +78,7 @@ func TestRisingWaveScaleViewControllerManagerImpl_GrabOrUpdateScaleViewLock(t *t
 	scaleView := testutils.NewFakeRisingWaveScaleViewFor(testutils.FakeRisingWave(), consts.ComponentFrontend)
 	scaleView.ResourceVersion = "1234"
 	scaleView.Finalizers = []string{consts.FinalizerScaleView}
-	scaleView.Spec.Replicas = 1
+	scaleView.Spec.Replicas = pointer.Int32(1)
 	scaleView.Spec.ScalePolicy = []risingwavev1alpha1.RisingWaveScaleViewSpecScalePolicy{
 		{
 			Group: "",
@@ -114,7 +115,7 @@ func TestRisingWaveScaleViewControllerManagerImpl_GrabOrUpdateScaleViewLock(t *t
 
 	// Change the scale view, try updating lock.
 	scaleView.Generation = 2
-	scaleView.Spec.Replicas = 2
+	scaleView.Spec.Replicas = pointer.Int32(2)
 
 	r, err = impl.GrabOrUpdateScaleViewLock(context.Background(), logr.Discard(), risingwave)
 	assert.Nil(t, err, "should be nil")

--- a/pkg/object/scaleview/split.go
+++ b/pkg/object/scaleview/split.go
@@ -74,7 +74,7 @@ func SplitReplicas(sv *risingwavev1alpha1.RisingWaveScaleView) map[string]int32 
 		return priorities[i] > priorities[j]
 	})
 
-	totalLeft := int(sv.Spec.Replicas)
+	totalLeft := int(pointer.Int32Deref(sv.Spec.Replicas, 0))
 	replicas := make(map[string]int32)
 
 	for _, priority := range priorities {
@@ -114,7 +114,7 @@ func SplitReplicas(sv *risingwavev1alpha1.RisingWaveScaleView) map[string]int32 
 	for _, r := range replicas {
 		sum += r
 	}
-	if sum != sv.Spec.Replicas {
+	if sum != pointer.Int32Deref(sv.Spec.Replicas, 0) {
 		panic("algorithm has bug")
 	}
 

--- a/pkg/object/scaleview/split_test.go
+++ b/pkg/object/scaleview/split_test.go
@@ -34,7 +34,7 @@ func TestScaleViewLockManager_splitReplicasIntoGroups(t *testing.T) {
 		"one": {
 			sv: risingwavev1alpha1.RisingWaveScaleView{
 				Spec: risingwavev1alpha1.RisingWaveScaleViewSpec{
-					Replicas: 10,
+					Replicas: pointer.Int32(10),
 					ScalePolicy: []risingwavev1alpha1.RisingWaveScaleViewSpecScalePolicy{
 						{
 							Group: "",
@@ -49,7 +49,7 @@ func TestScaleViewLockManager_splitReplicasIntoGroups(t *testing.T) {
 		"two-unlimited": {
 			sv: risingwavev1alpha1.RisingWaveScaleView{
 				Spec: risingwavev1alpha1.RisingWaveScaleViewSpec{
-					Replicas: 9,
+					Replicas: pointer.Int32(9),
 					ScalePolicy: []risingwavev1alpha1.RisingWaveScaleViewSpecScalePolicy{
 						{
 							Group: "a",
@@ -68,7 +68,7 @@ func TestScaleViewLockManager_splitReplicasIntoGroups(t *testing.T) {
 		"two-but-one-limited": {
 			sv: risingwavev1alpha1.RisingWaveScaleView{
 				Spec: risingwavev1alpha1.RisingWaveScaleViewSpec{
-					Replicas: 9,
+					Replicas: pointer.Int32(9),
 					ScalePolicy: []risingwavev1alpha1.RisingWaveScaleViewSpecScalePolicy{
 						{
 							Group: "a",
@@ -88,7 +88,7 @@ func TestScaleViewLockManager_splitReplicasIntoGroups(t *testing.T) {
 		"three-with-priorities-1": {
 			sv: risingwavev1alpha1.RisingWaveScaleView{
 				Spec: risingwavev1alpha1.RisingWaveScaleViewSpec{
-					Replicas: 9,
+					Replicas: pointer.Int32(9),
 					ScalePolicy: []risingwavev1alpha1.RisingWaveScaleViewSpecScalePolicy{
 						{
 							Group:       "a",
@@ -116,7 +116,7 @@ func TestScaleViewLockManager_splitReplicasIntoGroups(t *testing.T) {
 		"three-with-priorities-2": {
 			sv: risingwavev1alpha1.RisingWaveScaleView{
 				Spec: risingwavev1alpha1.RisingWaveScaleViewSpec{
-					Replicas: 9,
+					Replicas: pointer.Int32(9),
 					ScalePolicy: []risingwavev1alpha1.RisingWaveScaleViewSpecScalePolicy{
 						{
 							Group:    "a",
@@ -143,7 +143,7 @@ func TestScaleViewLockManager_splitReplicasIntoGroups(t *testing.T) {
 		"three-with-priorities-3": {
 			sv: risingwavev1alpha1.RisingWaveScaleView{
 				Spec: risingwavev1alpha1.RisingWaveScaleViewSpec{
-					Replicas: 4,
+					Replicas: pointer.Int32(4),
 					ScalePolicy: []risingwavev1alpha1.RisingWaveScaleViewSpecScalePolicy{
 						{
 							Group:       "a",
@@ -171,7 +171,7 @@ func TestScaleViewLockManager_splitReplicasIntoGroups(t *testing.T) {
 		"three-with-priorities-4": {
 			sv: risingwavev1alpha1.RisingWaveScaleView{
 				Spec: risingwavev1alpha1.RisingWaveScaleViewSpec{
-					Replicas: 4,
+					Replicas: pointer.Int32(4),
 					ScalePolicy: []risingwavev1alpha1.RisingWaveScaleViewSpecScalePolicy{
 						{
 							Group:       "a",

--- a/pkg/webhook/risingwave_scale_view_mutating_webhook.go
+++ b/pkg/webhook/risingwave_scale_view_mutating_webhook.go
@@ -79,9 +79,7 @@ func (w *RisingWaveScaleViewMutatingWebhook) readGroupReplicasFromRisingWave(ctx
 
 	// Set the default groups.
 	if len(obj.Spec.ScalePolicy) == 0 {
-		if r, _ := helper.ReadReplicas(""); r != 0 {
-			obj.Spec.ScalePolicy = append(obj.Spec.ScalePolicy, risingwavev1alpha1.RisingWaveScaleViewSpecScalePolicy{Group: ""})
-		}
+		obj.Spec.ScalePolicy = append(obj.Spec.ScalePolicy, risingwavev1alpha1.RisingWaveScaleViewSpecScalePolicy{Group: ""})
 		for _, group := range helper.ListComponentGroups() {
 			obj.Spec.ScalePolicy = append(obj.Spec.ScalePolicy, risingwavev1alpha1.RisingWaveScaleViewSpecScalePolicy{Group: group})
 		}

--- a/pkg/webhook/risingwave_scale_view_mutating_webhook.go
+++ b/pkg/webhook/risingwave_scale_view_mutating_webhook.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
@@ -108,7 +109,7 @@ func (w *RisingWaveScaleViewMutatingWebhook) readGroupReplicasFromRisingWave(ctx
 			)
 		}
 	}
-	obj.Spec.Replicas = replicas
+	obj.Spec.Replicas = pointer.Int32(replicas)
 
 	if len(fieldErrs) > 0 {
 		gvk := obj.GroupVersionKind()


### PR DESCRIPTION
…ween explicit zero and not specified

Signed-off-by: arkbriar <arkbriar@gmail.com>

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Avoids a problem when the replicas are explicitly 0, and the status sub-resource fails to work.
- Include the default group whenever the scaling policy isn't specified.

## Checklist

- [x] I have written the necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
