### PR TITLE
feat: add the `priorityClassName` field to the `RisingWaveComponentGroupTemplate`

### DIFF
--- a/apis/risingwave/v1alpha1/risingwave_types.go
+++ b/apis/risingwave/v1alpha1/risingwave_types.go
@@ -117,6 +117,15 @@ type RisingWaveComponentGroupTemplate struct {
 	// If specified, the pod's tolerations.
 	// +optional
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
+
+	// If specified, indicates the pod's priority. "system-node-critical" and
+	// "system-cluster-critical" are two special keywords which indicate the
+	// highest priorities with the former being the highest priority. Any other
+	// name must be defined by creating a PriorityClass object with that name.
+	// If not specified, the pod priority will be default or zero if there is no
+	// default.
+	// +optional
+	PriorityClassName string `json:"priorityClassName,omitempty"`
 }
 
 // RisingWaveComponentGroup is the common deployment group of each component. Currently, we use

--- a/config/crd/bases/risingwave.risingwavelabs.com_risingwaves.yaml
+++ b/config/crd/bases/risingwave.risingwavelabs.com_risingwaves.yaml
@@ -100,6 +100,15 @@ spec:
                                 default, there's no such template and the controller
                                 will set all unrelated fields to the default value.
                               type: string
+                            priorityClassName:
+                              description: If specified, indicates the pod's priority.
+                                "system-node-critical" and "system-cluster-critical"
+                                are two special keywords which indicate the highest
+                                priorities with the former being the highest priority.
+                                Any other name must be defined by creating a PriorityClass
+                                object with that name. If not specified, the pod priority
+                                will be default or zero if there is no default.
+                              type: string
                             replicas:
                               description: Replicas of Pods in this group.
                               format: int32
@@ -322,6 +331,15 @@ spec:
                               description: Base template for Pods of RisingWave. By
                                 default, there's no such template and the controller
                                 will set all unrelated fields to the default value.
+                              type: string
+                            priorityClassName:
+                              description: If specified, indicates the pod's priority.
+                                "system-node-critical" and "system-cluster-critical"
+                                are two special keywords which indicate the highest
+                                priorities with the former being the highest priority.
+                                Any other name must be defined by creating a PriorityClass
+                                object with that name. If not specified, the pod priority
+                                will be default or zero if there is no default.
                               type: string
                             replicas:
                               description: Replicas of Pods in this group.
@@ -592,6 +610,15 @@ spec:
                                 default, there's no such template and the controller
                                 will set all unrelated fields to the default value.
                               type: string
+                            priorityClassName:
+                              description: If specified, indicates the pod's priority.
+                                "system-node-critical" and "system-cluster-critical"
+                                are two special keywords which indicate the highest
+                                priorities with the former being the highest priority.
+                                Any other name must be defined by creating a PriorityClass
+                                object with that name. If not specified, the pod priority
+                                will be default or zero if there is no default.
+                              type: string
                             replicas:
                               description: Replicas of Pods in this group.
                               format: int32
@@ -816,6 +843,15 @@ spec:
                               description: Base template for Pods of RisingWave. By
                                 default, there's no such template and the controller
                                 will set all unrelated fields to the default value.
+                              type: string
+                            priorityClassName:
+                              description: If specified, indicates the pod's priority.
+                                "system-node-critical" and "system-cluster-critical"
+                                are two special keywords which indicate the highest
+                                priorities with the former being the highest priority.
+                                Any other name must be defined by creating a PriorityClass
+                                object with that name. If not specified, the pod priority
+                                will be default or zero if there is no default.
                               type: string
                             replicas:
                               description: Replicas of Pods in this group.
@@ -1069,6 +1105,14 @@ spec:
                     description: Base template for Pods of RisingWave. By default,
                       there's no such template and the controller will set all unrelated
                       fields to the default value.
+                    type: string
+                  priorityClassName:
+                    description: If specified, indicates the pod's priority. "system-node-critical"
+                      and "system-cluster-critical" are two special keywords which
+                      indicate the highest priorities with the former being the highest
+                      priority. Any other name must be defined by creating a PriorityClass
+                      object with that name. If not specified, the pod priority will
+                      be default or zero if there is no default.
                     type: string
                   replicas:
                     description: Replicas of each component in default groups.

--- a/config/risingwave-operator-test.yaml
+++ b/config/risingwave-operator-test.yaml
@@ -7023,6 +7023,15 @@ spec:
                                 default, there's no such template and the controller
                                 will set all unrelated fields to the default value.
                               type: string
+                            priorityClassName:
+                              description: If specified, indicates the pod's priority.
+                                "system-node-critical" and "system-cluster-critical"
+                                are two special keywords which indicate the highest
+                                priorities with the former being the highest priority.
+                                Any other name must be defined by creating a PriorityClass
+                                object with that name. If not specified, the pod priority
+                                will be default or zero if there is no default.
+                              type: string
                             replicas:
                               description: Replicas of Pods in this group.
                               format: int32
@@ -7245,6 +7254,15 @@ spec:
                               description: Base template for Pods of RisingWave. By
                                 default, there's no such template and the controller
                                 will set all unrelated fields to the default value.
+                              type: string
+                            priorityClassName:
+                              description: If specified, indicates the pod's priority.
+                                "system-node-critical" and "system-cluster-critical"
+                                are two special keywords which indicate the highest
+                                priorities with the former being the highest priority.
+                                Any other name must be defined by creating a PriorityClass
+                                object with that name. If not specified, the pod priority
+                                will be default or zero if there is no default.
                               type: string
                             replicas:
                               description: Replicas of Pods in this group.
@@ -7515,6 +7533,15 @@ spec:
                                 default, there's no such template and the controller
                                 will set all unrelated fields to the default value.
                               type: string
+                            priorityClassName:
+                              description: If specified, indicates the pod's priority.
+                                "system-node-critical" and "system-cluster-critical"
+                                are two special keywords which indicate the highest
+                                priorities with the former being the highest priority.
+                                Any other name must be defined by creating a PriorityClass
+                                object with that name. If not specified, the pod priority
+                                will be default or zero if there is no default.
+                              type: string
                             replicas:
                               description: Replicas of Pods in this group.
                               format: int32
@@ -7739,6 +7766,15 @@ spec:
                               description: Base template for Pods of RisingWave. By
                                 default, there's no such template and the controller
                                 will set all unrelated fields to the default value.
+                              type: string
+                            priorityClassName:
+                              description: If specified, indicates the pod's priority.
+                                "system-node-critical" and "system-cluster-critical"
+                                are two special keywords which indicate the highest
+                                priorities with the former being the highest priority.
+                                Any other name must be defined by creating a PriorityClass
+                                object with that name. If not specified, the pod priority
+                                will be default or zero if there is no default.
                               type: string
                             replicas:
                               description: Replicas of Pods in this group.
@@ -7992,6 +8028,14 @@ spec:
                     description: Base template for Pods of RisingWave. By default,
                       there's no such template and the controller will set all unrelated
                       fields to the default value.
+                    type: string
+                  priorityClassName:
+                    description: If specified, indicates the pod's priority. "system-node-critical"
+                      and "system-cluster-critical" are two special keywords which
+                      indicate the highest priorities with the former being the highest
+                      priority. Any other name must be defined by creating a PriorityClass
+                      object with that name. If not specified, the pod priority will
+                      be default or zero if there is no default.
                     type: string
                   replicas:
                     description: Replicas of each component in default groups.

--- a/config/risingwave-operator.yaml
+++ b/config/risingwave-operator.yaml
@@ -7023,6 +7023,15 @@ spec:
                                 default, there's no such template and the controller
                                 will set all unrelated fields to the default value.
                               type: string
+                            priorityClassName:
+                              description: If specified, indicates the pod's priority.
+                                "system-node-critical" and "system-cluster-critical"
+                                are two special keywords which indicate the highest
+                                priorities with the former being the highest priority.
+                                Any other name must be defined by creating a PriorityClass
+                                object with that name. If not specified, the pod priority
+                                will be default or zero if there is no default.
+                              type: string
                             replicas:
                               description: Replicas of Pods in this group.
                               format: int32
@@ -7245,6 +7254,15 @@ spec:
                               description: Base template for Pods of RisingWave. By
                                 default, there's no such template and the controller
                                 will set all unrelated fields to the default value.
+                              type: string
+                            priorityClassName:
+                              description: If specified, indicates the pod's priority.
+                                "system-node-critical" and "system-cluster-critical"
+                                are two special keywords which indicate the highest
+                                priorities with the former being the highest priority.
+                                Any other name must be defined by creating a PriorityClass
+                                object with that name. If not specified, the pod priority
+                                will be default or zero if there is no default.
                               type: string
                             replicas:
                               description: Replicas of Pods in this group.
@@ -7515,6 +7533,15 @@ spec:
                                 default, there's no such template and the controller
                                 will set all unrelated fields to the default value.
                               type: string
+                            priorityClassName:
+                              description: If specified, indicates the pod's priority.
+                                "system-node-critical" and "system-cluster-critical"
+                                are two special keywords which indicate the highest
+                                priorities with the former being the highest priority.
+                                Any other name must be defined by creating a PriorityClass
+                                object with that name. If not specified, the pod priority
+                                will be default or zero if there is no default.
+                              type: string
                             replicas:
                               description: Replicas of Pods in this group.
                               format: int32
@@ -7739,6 +7766,15 @@ spec:
                               description: Base template for Pods of RisingWave. By
                                 default, there's no such template and the controller
                                 will set all unrelated fields to the default value.
+                              type: string
+                            priorityClassName:
+                              description: If specified, indicates the pod's priority.
+                                "system-node-critical" and "system-cluster-critical"
+                                are two special keywords which indicate the highest
+                                priorities with the former being the highest priority.
+                                Any other name must be defined by creating a PriorityClass
+                                object with that name. If not specified, the pod priority
+                                will be default or zero if there is no default.
                               type: string
                             replicas:
                               description: Replicas of Pods in this group.
@@ -7992,6 +8028,14 @@ spec:
                     description: Base template for Pods of RisingWave. By default,
                       there's no such template and the controller will set all unrelated
                       fields to the default value.
+                    type: string
+                  priorityClassName:
+                    description: If specified, indicates the pod's priority. "system-node-critical"
+                      and "system-cluster-critical" are two special keywords which
+                      indicate the highest priorities with the former being the highest
+                      priority. Any other name must be defined by creating a PriorityClass
+                      object with that name. If not specified, the pod priority will
+                      be default or zero if there is no default.
                     type: string
                   replicas:
                     description: Replicas of each component in default groups.

--- a/docs/general/api.md
+++ b/docs/general/api.md
@@ -712,6 +712,23 @@ and the controller will set all unrelated fields to the default value.</p>
 <p>If specified, the pod&rsquo;s tolerations.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>priorityClassName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>If specified, indicates the pod&rsquo;s priority. &ldquo;system-node-critical&rdquo; and
+&ldquo;system-cluster-critical&rdquo; are two special keywords which indicate the
+highest priorities with the former being the highest priority. Any other
+name must be defined by creating a PriorityClass object with that name.
+If not specified, the pod priority will be default or zero if there is no
+default.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="risingwave.risingwavelabs.com/v1alpha1.RisingWaveComponentMeta">RisingWaveComponentMeta
@@ -1139,6 +1156,23 @@ and the controller will set all unrelated fields to the default value.</p>
 </tr>
 <tr>
 <td>
+<code>priorityClassName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>If specified, indicates the pod&rsquo;s priority. &ldquo;system-node-critical&rdquo; and
+&ldquo;system-cluster-critical&rdquo; are two special keywords which indicate the
+highest priorities with the former being the highest priority. Any other
+name must be defined by creating a PriorityClass object with that name.
+If not specified, the pod priority will be default or zero if there is no
+default.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>volumeMounts</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#volumemount-v1-core">
@@ -1483,6 +1517,23 @@ and the controller will set all unrelated fields to the default value.</p>
 <td>
 <em>(Optional)</em>
 <p>If specified, the pod&rsquo;s tolerations.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>priorityClassName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>If specified, indicates the pod&rsquo;s priority. &ldquo;system-node-critical&rdquo; and
+&ldquo;system-cluster-critical&rdquo; are two special keywords which indicate the
+highest priorities with the former being the highest priority. Any other
+name must be defined by creating a PriorityClass object with that name.
+If not specified, the pod priority will be default or zero if there is no
+default.</p>
 </td>
 </tr>
 <tr>

--- a/pkg/factory/risingwave_object_factory.go
+++ b/pkg/factory/risingwave_object_factory.go
@@ -857,6 +857,9 @@ func (f *RisingWaveObjectFactory) buildPodTemplate(component, group string, podT
 
 		// Set the tolerations.
 		podTemplate.Spec.Tolerations = append(podTemplate.Spec.Tolerations, groupTemplate.Tolerations...)
+
+		// Set the PriorityClassName.
+		podTemplate.Spec.PriorityClassName = groupTemplate.PriorityClassName
 	}
 
 	// Set config volume.

--- a/pkg/factory/risingwave_object_factory_test.go
+++ b/pkg/factory/risingwave_object_factory_test.go
@@ -702,6 +702,16 @@ func Test_RisingWaveObjectFactory_Deployments(t *testing.T) {
 				},
 			},
 		},
+		"priority-class-name": {
+			group: risingwavev1alpha1.RisingWaveComponentGroup{
+				Name:     "",
+				Replicas: int32(rand.Intn(math.MaxInt32)),
+				RisingWaveComponentGroupTemplate: &risingwavev1alpha1.RisingWaveComponentGroupTemplate{
+					Image:             rand.String(20),
+					PriorityClassName: "high-priority",
+				},
+			},
+		},
 		"default-group": {
 			group: risingwavev1alpha1.RisingWaveComponentGroup{
 				Name:     "",
@@ -943,6 +953,9 @@ func Test_RisingWaveObjectFactory_Deployments(t *testing.T) {
 					newObjectAssert(deploy, "tolerations-match", func(obj *appsv1.Deployment) bool {
 						return equality.Semantic.DeepEqual(obj.Spec.Template.Spec.Tolerations, tc.group.Tolerations)
 					}),
+					newObjectAssert(deploy, "priority-class-name-match", func(obj *appsv1.Deployment) bool {
+						return obj.Spec.Template.Spec.PriorityClassName == tc.group.PriorityClassName
+					}),
 					newObjectAssert(deploy, "upgrade-strategy-match", func(obj *appsv1.Deployment) bool {
 						if tc.expectUpgradeStrategy == nil {
 							return equality.Semantic.DeepEqual(obj.Spec.Strategy, appsv1.DeploymentStrategy{})
@@ -1003,6 +1016,16 @@ func Test_RisingWaveObjectFactory_CloneSet(t *testing.T) {
 							TolerationSeconds: &[]int64{3600}[0],
 						},
 					},
+				},
+			},
+		},
+		"priority-class-name": {
+			group: risingwavev1alpha1.RisingWaveComponentGroup{
+				Name:     "",
+				Replicas: int32(rand.Intn(math.MaxInt32)),
+				RisingWaveComponentGroupTemplate: &risingwavev1alpha1.RisingWaveComponentGroupTemplate{
+					Image:             rand.String(20),
+					PriorityClassName: "high-priority",
 				},
 			},
 		},
@@ -1530,6 +1553,9 @@ func Test_RisingWaveObjectFactory_CloneSet(t *testing.T) {
 					newObjectAssert(cloneSet, "tolerations-match", func(obj *kruiseappsv1alpha1.CloneSet) bool {
 						return equality.Semantic.DeepEqual(obj.Spec.Template.Spec.Tolerations, tc.group.Tolerations)
 					}),
+					newObjectAssert(cloneSet, "priority-class-name-match", func(obj *kruiseappsv1alpha1.CloneSet) bool {
+						return obj.Spec.Template.Spec.PriorityClassName == tc.group.PriorityClassName
+					}),
 					newObjectAssert(cloneSet, "upgrade-strategy-match", func(obj *kruiseappsv1alpha1.CloneSet) bool {
 						if tc.expectedUpgradeStrategy == nil {
 							return equality.Semantic.DeepEqual(obj.Spec.UpdateStrategy, kruiseappsv1alpha1.CloneSetUpdateStrategy{})
@@ -1584,6 +1610,18 @@ func Test_RisingWaveObjectFactory_StatefulSets(t *testing.T) {
 								TolerationSeconds: &[]int64{3600}[0],
 							},
 						},
+					},
+				},
+			},
+		},
+		"priority-class-name": {
+			group: risingwavev1alpha1.RisingWaveComputeGroup{
+				Name:     "",
+				Replicas: int32(rand.Intn(math.MaxInt32)),
+				RisingWaveComputeGroupTemplate: &risingwavev1alpha1.RisingWaveComputeGroupTemplate{
+					RisingWaveComponentGroupTemplate: risingwavev1alpha1.RisingWaveComponentGroupTemplate{
+						Image:             rand.String(20),
+						PriorityClassName: "high-priority",
 					},
 				},
 			},
@@ -1828,6 +1866,9 @@ func Test_RisingWaveObjectFactory_StatefulSets(t *testing.T) {
 				newObjectAssert(sts, "tolerations-match", func(obj *appsv1.StatefulSet) bool {
 					return equality.Semantic.DeepEqual(obj.Spec.Template.Spec.Tolerations, tc.group.Tolerations)
 				}),
+				newObjectAssert(sts, "priority-class-name-match", func(obj *appsv1.StatefulSet) bool {
+					return obj.Spec.Template.Spec.PriorityClassName == tc.group.PriorityClassName
+				}),
 				newObjectAssert(sts, "upgrade-strategy-match", func(obj *appsv1.StatefulSet) bool {
 					if tc.expectUpgradeStrategy == nil {
 						return equality.Semantic.DeepEqual(obj.Spec.UpdateStrategy, appsv1.StatefulSetUpdateStrategy{})
@@ -1884,6 +1925,18 @@ func Test_RisingWaveObjectFactory_AdvancedStatefulSets(t *testing.T) {
 								TolerationSeconds: &[]int64{3600}[0],
 							},
 						},
+					},
+				},
+			},
+		},
+		"priority-class-name": {
+			group: risingwavev1alpha1.RisingWaveComputeGroup{
+				Name:     "",
+				Replicas: int32(rand.Intn(math.MaxInt32)),
+				RisingWaveComputeGroupTemplate: &risingwavev1alpha1.RisingWaveComputeGroupTemplate{
+					RisingWaveComponentGroupTemplate: risingwavev1alpha1.RisingWaveComponentGroupTemplate{
+						Image:             rand.String(20),
+						PriorityClassName: "high-priority",
 					},
 				},
 			},
@@ -2218,6 +2271,9 @@ func Test_RisingWaveObjectFactory_AdvancedStatefulSets(t *testing.T) {
 				}),
 				newObjectAssert(asts, "tolerations-match", func(obj *kruiseappsv1beta1.StatefulSet) bool {
 					return equality.Semantic.DeepEqual(obj.Spec.Template.Spec.Tolerations, tc.group.Tolerations)
+				}),
+				newObjectAssert(asts, "priority-class-name-match", func(obj *kruiseappsv1beta1.StatefulSet) bool {
+					return obj.Spec.Template.Spec.PriorityClassName == tc.group.PriorityClassName
 				}),
 				newObjectAssert(asts, "upgrade-strategy-match", func(obj *kruiseappsv1beta1.StatefulSet) bool {
 					if tc.expectedUpgradeStrategy == nil {


### PR DESCRIPTION
## What's changed and what's your intention?

- add the `priorityClassName` field to the `RisingWaveComponentGroupTemplate`

## Checklist

- [x] I have written the necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
https://github.com/risingwavelabs/risingwave-operator/issues/259