### PR TITLE
fix: use ceil instead of floor

### DIFF
--- a/pkg/factory/risingwave_object_factory.go
+++ b/pkg/factory/risingwave_object_factory.go
@@ -1531,7 +1531,7 @@ func (f *RisingWaveObjectFactory) setupComputeContainer(container *corev1.Contai
 
 	container.Name = "compute"
 
-	cpuLimit := int64(math.Floor(container.Resources.Limits.Cpu().AsApproximateFloat64()))
+	cpuLimit := int64(math.Ceil(container.Resources.Limits.Cpu().AsApproximateFloat64()))
 	memLimit, _ := container.Resources.Limits.Memory().AsInt64()
 	container.Args = f.argsForCompute(cpuLimit, memLimit)
 	container.Ports = f.portsForComputeContainer()


### PR DESCRIPTION
Signed-off-by: arkbriar <arkbriar@gmail.com>

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- As title. `Floor` is a bug and will result in an incorrect value when the CPU limit isn't an integer.

## Checklist

- [x] I have written the necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
