### PR TITLE
feat(chore): install monitoring stack in parallel

### DIFF
--- a/monitoring/install.sh
+++ b/monitoring/install.sh
@@ -99,10 +99,11 @@ if [[ $r = true ]]; then
     # Install the `kube-prometheus-stack` with remote write
     rParams=" -r -s $s -k $k "
 fi 
-./kube-prometheus-stack/install.sh $rParams $dryParam -n $ns
+./kube-prometheus-stack/install.sh $rParams $dryParam -n $ns &
 
 # Install the `loki-distributed`
-./loki-distributed/install.sh $dryParam -n $ns
+./loki-distributed/install.sh $dryParam -n $ns &
 
 # Install the `promtail`
-./promtail/install.sh $dryParam -n $ns
+./promtail/install.sh $dryParam -n $ns & 
+wait

--- a/test/e2e/e2e.sh
+++ b/test/e2e/e2e.sh
@@ -161,7 +161,7 @@ function e2e::run() {
   IFS=" " read -r -a testcases <<<"$(e2e::list_test_cases)"
   local total_cnt="${#testcases[@]}"
   logging::infof "Running tests, total %d...\n" "${total_cnt}"
-  if [ ${OPEN_KRUISE_ENABLED_IN_RISINGWAVE} -eq 1 ]; then
+  if [ "${OPEN_KRUISE_ENABLED_IN_RISINGWAVE}" -eq 1 ]; then
     testenv::k8s::risingwave_operator::enable_openkruise
   fi
 


### PR DESCRIPTION
## What's changed and what's your intention?

Lets install all monitoring components in parallel. No need to wait for each of them individually. 

## Checklist

- [x] I have written the necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
