### PR TITLE
chore: bump go toolchain to 1.20

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -122,12 +122,12 @@ linters-settings:
     - unusedwrite
 
   staticcheck:
-    go: "1.19"
+    go: "1.20"
     # https://staticcheck.io/docs/options#checks
     checks: [ "all" ]
 
   stylecheck:
-    go: "1.19"
+    go: "1.20"
     # https://staticcheck.io/docs/options#checks
     checks: [ "all", "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022" ]
     # https://staticcheck.io/docs/options#dot_import_whitelist

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,7 +1,7 @@
 ARG USE_VENDOR=false
 
 # Build the manager binary
-FROM golang:1.19 as base
+FROM golang:1.20 as base
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/risingwavelabs/risingwave-operator
 
-go 1.19
+go 1.20
 
 require (
 	github.com/BurntSushi/toml v1.0.0


### PR DESCRIPTION
Signed-off-by: arkbriar <arkbriar@gmail.com>

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Bump go toolchain to 1.20, and update the golangci config and Dockerfile

## Checklist

- [x] I have written the necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
