### PR TITLE
fix: use new arguments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ build-local-certs:
 		-extensions san -config <(echo '[req]'; echo 'distinguished_name=req'; echo '[san]'; echo 'subjectAltName=DNS:host.docker.internal')
 
 install-local: kustomize manifests
-	$(KUSTOMIZE) build config/local | kubectl apply -f - >/dev/null
+	$(KUSTOMIZE) build config/local | kubectl apply --server-side --force-conflicts -f - >/dev/null
 
 uninstall-local: kustomize manifests
 	$(KUSTOMIZE) build config/local | kubectl delete -f - >/dev/null

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ the `cert-manager` [can be found here](https://cert-manager.io/docs/installation
 Afterward, you can install the `risingwave-operator` with the following command:
 
 ```shell
-kubectl apply -f https://github.com/risingwavelabs/risingwave-operator/releases/latest/download/risingwave-operator.yaml
+kubectl apply --server-side -f https://github.com/risingwavelabs/risingwave-operator/releases/latest/download/risingwave-operator.yaml
 ```
 
 To check if the installation is successful, you can run the following commands to check if the Pods are all running.

--- a/docs/dev/rampup_example.md
+++ b/docs/dev/rampup_example.md
@@ -198,6 +198,6 @@ mgr.risingwaveManager.UpdateStatus(func(status *risingwavev1alpha1.RisingWaveSta
     Because we have not start the controller, there is not value in `VERSION`. Run `make run-local` to start controller, the controller will update the field:
     ```bash
     NAME                   RUNNING   STORAGE(META)   STORAGE(OBJECT)   VERSION   AGE
-    risingwave-in-memory   True      Memory          Memory            v0.1.16   20m
+    risingwave-in-memory   True      Memory          Memory            v0.1.17   20m
     ```
 5. When we launch the k8s, the k8s will update the name. The controller will update the `status` field, the k8s will collect the column we want and show it.

--- a/docs/manifests/risingwave/risingwave-aliyun-oss.yaml
+++ b/docs/manifests/risingwave/risingwave-aliyun-oss.yaml
@@ -35,7 +35,7 @@ spec:
         bucket: hummock001
         internalEndpoint: true
   global:
-    image: ghcr.io/risingwavelabs/risingwave:nightly-20221107
+    image: ghcr.io/risingwavelabs/risingwave:v0.1.17
     imagePullPolicy: IfNotPresent
     resources:
       limits:

--- a/docs/manifests/risingwave/risingwave-component-groups.yaml
+++ b/docs/manifests/risingwave/risingwave-component-groups.yaml
@@ -9,7 +9,7 @@ spec:
     object:
       memory: true
   global:
-    image: ghcr.io/risingwavelabs/risingwave:v0.1.16
+    image: ghcr.io/risingwavelabs/risingwave:v0.1.17
     imagePullPolicy: IfNotPresent
     resources:
       limits:

--- a/docs/manifests/risingwave/risingwave-component-only.yaml
+++ b/docs/manifests/risingwave/risingwave-component-only.yaml
@@ -13,7 +13,7 @@ spec:
       groups:
       - name: default
         replicas: 1
-        image: ghcr.io/risingwavelabs/risingwave:v0.1.16
+        image: ghcr.io/risingwavelabs/risingwave:v0.1.17
         resources:
           limits:
             cpu: 1
@@ -25,7 +25,7 @@ spec:
       groups:
       - name: default
         replicas: 1
-        image: ghcr.io/risingwavelabs/risingwave:v0.1.16
+        image: ghcr.io/risingwavelabs/risingwave:v0.1.17
         resources:
           limits:
             cpu: 1
@@ -37,7 +37,7 @@ spec:
       groups:
       - name: default
         replicas: 1
-        image: ghcr.io/risingwavelabs/risingwave:v0.1.16
+        image: ghcr.io/risingwavelabs/risingwave:v0.1.17
         resources:
           limits:
             cpu: 1
@@ -49,7 +49,7 @@ spec:
       groups:
       - name: default
         replicas: 1
-        image: ghcr.io/risingwavelabs/risingwave:v0.1.16
+        image: ghcr.io/risingwavelabs/risingwave:v0.1.17
         resources:
           limits:
             cpu: 1

--- a/docs/manifests/risingwave/risingwave-customize-config.yaml
+++ b/docs/manifests/risingwave/risingwave-customize-config.yaml
@@ -39,7 +39,7 @@ spec:
     object:
       memory: true
   global:
-    image: ghcr.io/risingwavelabs/risingwave:v0.1.16
+    image: ghcr.io/risingwavelabs/risingwave:v0.1.17
     imagePullPolicy: IfNotPresent
     resources:
       limits:

--- a/docs/manifests/risingwave/risingwave-etcd-auth.yaml
+++ b/docs/manifests/risingwave/risingwave-etcd-auth.yaml
@@ -94,7 +94,7 @@ spec:
     object:
       memory: true
   global:
-    image: ghcr.io/risingwavelabs/risingwave:v0.1.16
+    image: ghcr.io/risingwavelabs/risingwave:v0.1.17
     imagePullPolicy: IfNotPresent
     resources:
       limits:

--- a/docs/manifests/risingwave/risingwave-etcd-minio.yaml
+++ b/docs/manifests/risingwave/risingwave-etcd-minio.yaml
@@ -151,7 +151,7 @@ spec:
         endpoint: risingwave-minio:9301
         bucket: hummock001
   global:
-    image: ghcr.io/risingwavelabs/risingwave:v0.1.16
+    image: ghcr.io/risingwavelabs/risingwave:v0.1.17
     imagePullPolicy: IfNotPresent
     resources:
       limits:

--- a/docs/manifests/risingwave/risingwave-etcd-s3.yaml
+++ b/docs/manifests/risingwave/risingwave-etcd-s3.yaml
@@ -91,7 +91,7 @@ spec:
         region: ap-southeast-1
         bucket: hummock001
   global:
-    image: ghcr.io/risingwavelabs/risingwave:v0.1.16
+    image: ghcr.io/risingwavelabs/risingwave:v0.1.17
     imagePullPolicy: IfNotPresent
     resources:
       limits:

--- a/docs/manifests/risingwave/risingwave-hdfs.yaml
+++ b/docs/manifests/risingwave/risingwave-hdfs.yaml
@@ -15,7 +15,7 @@ spec:
         nameNode: your-nameNode
         root: your-root
   global:
-    image: ghcr.io/risingwavelabs/risingwave:nightly-20221107
+    image: ghcr.io/risingwavelabs/risingwave:v0.1.17
     imagePullPolicy: IfNotPresent
     resources:
       limits:

--- a/docs/manifests/risingwave/risingwave-in-memory.yaml
+++ b/docs/manifests/risingwave/risingwave-in-memory.yaml
@@ -9,7 +9,7 @@ spec:
     object:
       memory: true
   global:
-    image: ghcr.io/risingwavelabs/risingwave:v0.1.16
+    image: ghcr.io/risingwavelabs/risingwave:v0.1.17
     imagePullPolicy: IfNotPresent
     resources:
       limits:

--- a/docs/manifests/risingwave/risingwave-in-memory.yaml
+++ b/docs/manifests/risingwave/risingwave-in-memory.yaml
@@ -11,13 +11,6 @@ spec:
   global:
     image: ghcr.io/risingwavelabs/risingwave:v0.1.17
     imagePullPolicy: IfNotPresent
-    resources:
-      limits:
-        cpu: 1
-        memory: 1Gi
-      requests:
-        cpu: 100m
-        memory: 100Mi
     replicas:
       meta: 1
       frontend: 1

--- a/docs/manifests/risingwave/risingwave-privileged.yaml
+++ b/docs/manifests/risingwave/risingwave-privileged.yaml
@@ -23,7 +23,7 @@ spec:
     object:
       memory: true
   global:
-    image: ghcr.io/risingwavelabs/risingwave:v0.1.16
+    image: ghcr.io/risingwavelabs/risingwave:v0.1.17
     imagePullPolicy: IfNotPresent
     podTemplate: privileged
     resources:

--- a/docs/manifests/risingwave/risingwave-s3-compatible.yaml
+++ b/docs/manifests/risingwave/risingwave-s3-compatible.yaml
@@ -22,7 +22,7 @@ spec:
         endpoint: cos.${REGION}.myqcloud.com
         virtualHostedStyle: true
   global:
-    image: ghcr.io/risingwavelabs/risingwave:nightly-20221107
+    image: ghcr.io/risingwavelabs/risingwave:v0.1.17
     imagePullPolicy: IfNotPresent
     resources:
       limits:

--- a/docs/manifests/risingwave/risingwave-spot-toleration.yaml
+++ b/docs/manifests/risingwave/risingwave-spot-toleration.yaml
@@ -24,7 +24,7 @@ spec:
     object:
       memory: true
   global:
-    image: ghcr.io/risingwavelabs/risingwave:v0.1.16
+    image: ghcr.io/risingwavelabs/risingwave:v0.1.17
     imagePullPolicy: IfNotPresent
     resources:
       limits:

--- a/docs/manifests/risingwavescaleview/sv-example-frontend.yaml
+++ b/docs/manifests/risingwavescaleview/sv-example-frontend.yaml
@@ -9,7 +9,7 @@ spec:
     object:
       memory: true
   global:
-    image: ghcr.io/risingwavelabs/risingwave:v0.1.16
+    image: ghcr.io/risingwavelabs/risingwave:v0.1.17
     replicas:
       meta: 1
       frontend: 1

--- a/docs/manifests/risingwavescaleview/sv-spot-compactor.yaml
+++ b/docs/manifests/risingwavescaleview/sv-spot-compactor.yaml
@@ -9,7 +9,7 @@ spec:
     object:
       memory: true
   global:
-    image: ghcr.io/risingwavelabs/risingwave:v0.1.16
+    image: ghcr.io/risingwavelabs/risingwave:v0.1.17
     replicas:
       meta: 1
       frontend: 1

--- a/e2e/env-utils
+++ b/e2e/env-utils
@@ -59,7 +59,7 @@ function prepare_cluster() {
   esac
 
   # Override the nightly tag to keep test stable.
-  NIGHTLY_IMAGE_TAG=v0.1.16
+  NIGHTLY_IMAGE_TAG=v0.1.17
 
   echo "Using a nightly tag $NIGHTLY_IMAGE_TAG for RisingWave images..."
 

--- a/hack/scripts/install.sh
+++ b/hack/scripts/install.sh
@@ -47,7 +47,7 @@ function k8s::risingwave_operator::install() {
   manifest_link=$(link_to_risingwave_operator_manifests "${RISINGWAVE_OPERATOR_VERSION}")
 
   echo "Installing the risingwave-operator ${RISINGWAVE_OPERATOR_VERSION}..."
-  kubectl apply -f "${manifest_link}" >/dev/null
+  kubectl apply --server-side -f "${manifest_link}" >/dev/null
 }
 
 k8s::cert_manager::install && k8s::cert_manager::wait && k8s::risingwave_operator::install

--- a/pkg/factory/risingwave_object_factory_test.go
+++ b/pkg/factory/risingwave_object_factory_test.go
@@ -3212,23 +3212,15 @@ func Test_RisingWaveObjectFactory_ObjectStorages(t *testing.T) {
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
 			risingwave := newTestRisingwave(func(r *risingwavev1alpha1.RisingWave) {
+				r.Spec.Storages.Meta = risingwavev1alpha1.RisingWaveMetaStorage{
+					Memory: pointer.Bool(true),
+				}
 				r.Spec.Storages.Object = tc.objectStorage
 			})
 
 			factory := NewRisingWaveObjectFactory(risingwave, testutils.Scheme)
 
-			deploy := factory.NewCompactorDeployment("", nil)
-
-			composeAssertions(
-				newObjectAssert(deploy, "hummock-args-match", func(obj *appsv1.Deployment) bool {
-					return lo.Contains(obj.Spec.Template.Spec.Containers[0].Args, tc.hummockArg)
-				}),
-				newObjectAssert(deploy, "env-vars-contains", func(obj *appsv1.Deployment) bool {
-					return listContainsByKey(obj.Spec.Template.Spec.Containers[0].Env, tc.envs, func(t *corev1.EnvVar) string { return t.Name }, deepEqual[corev1.EnvVar])
-				}),
-			).Assert(t)
-
-			sts := factory.NewComputeStatefulSet("", nil)
+			sts := factory.NewMetaStatefulSet("", nil)
 
 			composeAssertions(
 				newObjectAssert(sts, "hummock-args-match", func(obj *appsv1.StatefulSet) bool {
@@ -3322,6 +3314,9 @@ func Test_RisingWaveObjectFactory_MetaStorages(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			risingwave := newTestRisingwave(func(r *risingwavev1alpha1.RisingWave) {
 				r.Spec.Storages.Meta = tc.metaStorage
+				r.Spec.Storages.Object = risingwavev1alpha1.RisingWaveObjectStorage{
+					Memory: pointer.Bool(true),
+				}
 			})
 
 			factory := NewRisingWaveObjectFactory(risingwave, testutils.Scheme)

--- a/pkg/utils/common_test.go
+++ b/pkg/utils/common_test.go
@@ -31,8 +31,8 @@ func Test_CommonGetVersionFromImage(t *testing.T) {
 			version: "",
 		},
 		"image-version": {
-			image:   "ghcr.io/risingwavelabs/risingwave:v0.1.16",
-			version: "v0.1.16",
+			image:   "ghcr.io/risingwavelabs/risingwave:v0.1.17",
+			version: "v0.1.17",
 		},
 		"image-port-default": {
 			image:   "ghcr.io:10043/risingwavelabs/risingwave",

--- a/test/e2e/e2e.sh
+++ b/test/e2e/e2e.sh
@@ -197,9 +197,6 @@ function e2e::pre_run() {
 
   shell::run docker pull "${E2E_RISINGWAVE_IMAGE}" || return $?
   testenv::k8s::load_docker_image "${E2E_RISINGWAVE_IMAGE}"
-
-  shell::run docker pull "${E2E_RISINGWAVE_NIGHTLY_IMAGE}" || return $?
-  testenv::k8s::load_docker_image "${E2E_RISINGWAVE_NIGHTLY_IMAGE}"
 }
 
 function e2e::post_run() {

--- a/test/e2e/env
+++ b/test/e2e/env
@@ -1,5 +1,5 @@
 E2E_KUBERNETES_RUNTIME=kind
-E2E_RISINGWAVE_IMAGE=ghcr.io/risingwavelabs/risingwave:v0.1.16
+E2E_RISINGWAVE_IMAGE=ghcr.io/risingwavelabs/risingwave:v0.1.17
 E2E_AWS_S3_REGION=
 E2E_AWS_S3_BUCKET=
 E2E_AWS_ACCESS_KEY_ID=

--- a/test/e2e/testenv/lib.sh
+++ b/test/e2e/testenv/lib.sh
@@ -164,7 +164,7 @@ _RISINGWAVE_OPERATOR_ENABLE_OPENKRUISE_PATCH_FILE="$(dirname "${BASH_SOURCE[0]}"
 
 function testenv::k8s::risingwave_operator::install() {
   testenv::k8s::load_docker_image "${_RISINGWAVE_OPERATOR_TEST_IMAGE}"
-  shell::run k8s::kubectl apply -f "${_RISINGWAVE_OPERATOR_MANIFEST_FOR_TEST_PATH}"
+  shell::run k8s::kubectl apply --server-side -f "${_RISINGWAVE_OPERATOR_MANIFEST_FOR_TEST_PATH}"
 
   # shellcheck disable=SC2034
   local KUBECTL_NAMESPACE="${_RISINGWAVE_OPERATOR_NAMESPACE}"

--- a/test/e2e/tests/risingwave/manifests/connector/connector-test.yaml
+++ b/test/e2e/tests/risingwave/manifests/connector/connector-test.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: ${E2E_NAMESPACE}
 spec:
   global:
-    image: ${E2E_RISINGWAVE_NIGHTLY_IMAGE}
+    image: ${E2E_RISINGWAVE_IMAGE}
     imagePullPolicy: IfNotPresent
     replicas:
       meta: 1

--- a/test/e2e/tests/risingwave/manifests/multi-meta/multi-meta.yaml
+++ b/test/e2e/tests/risingwave/manifests/multi-meta/multi-meta.yaml
@@ -77,7 +77,7 @@ metadata:
   namespace: ${E2E_NAMESPACE}
 spec:
   global:
-    image: ${E2E_RISINGWAVE_NIGHTLY_IMAGE}
+    image: ${E2E_RISINGWAVE_IMAGE}
     imagePullPolicy: IfNotPresent
     replicas:
       meta: 2

--- a/test/e2e/tests/tests.sh
+++ b/test/e2e/tests/tests.sh
@@ -15,8 +15,7 @@
 ${__E2E_SOURCE_TESTS_TESTS_SH__:=false} && return 0 || __E2E_SOURCE_TESTS_TESTS_SH__=true
 
 export E2E_RISINGWAVE_NAME="${E2E_RISINGWAVE_NAME:=e2e}"
-export E2E_RISINGWAVE_IMAGE="${E2E_RISINGWAVE_IMAGE:=ghcr.io/risingwavelabs/risingwave:v0.1.16}"
-export E2E_RISINGWAVE_NIGHTLY_IMAGE="${E2E_RISINGWAVE_NIGHTLY_IMAGE:=ghcr.io/risingwavelabs/risingwave:nightly-20230216}"
+export E2E_RISINGWAVE_IMAGE="${E2E_RISINGWAVE_IMAGE:=ghcr.io/risingwavelabs/risingwave:v0.1.17}"
 
 source "$(dirname "${BASH_SOURCE[0]}")/risingwave/tests.sh"
 source "$(dirname "${BASH_SOURCE[0]}")/risingwavescaleview/tests.sh"


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Use `--listen-addr` and `--advertise-addr`, deprecate the usages of `--host` and `--client-addr`.(https://github.com/risingwavelabs/risingwave/issues/7625, https://github.com/risingwavelabs/risingwave/issues/7678)
- Move the `--state-store` and credential envs to the meta nodes. (https://github.com/risingwavelabs/risingwave/issues/7860)
- Update the image versions to use `v0.1.17`
- Fix the `kubectl apply` in e2e tests and README

After this change, the minimum supported RisingWave version is `v0.1.17`.

## Checklist

- [x] I have written the necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

fix CLOUD-988 CLOUD-989 CLOUD-990 CLOUD-991 CLOUD-992 CLOUD-899