### PR TITLE
fix: set a timeout to avoid potential hangups or delays in getMetaRole

### DIFF
--- a/pkg/controller/meta_pod_role_labeler.go
+++ b/pkg/controller/meta_pod_role_labeler.go
@@ -149,7 +149,11 @@ func (mpl *MetaPodRoleLabeler) syncRoleLabelForSinglePod(ctx context.Context, po
 	logger := log.FromContext(ctx).WithValues("pod", pod.Name)
 
 	// Send a gRPC request and get the current role.
-	role, err := mpl.getMetaRole(ctx, pod.Status.PodIP, uint(svcPort), endpoint)
+	role, err := func() (string, error) {
+		ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		defer cancel()
+		return mpl.getMetaRole(ctx, pod.Status.PodIP, uint(svcPort), endpoint)
+	}()
 	if err != nil {
 		logger.Info("Failed to get the current role from the meta Pod.", "error", err)
 		// Use an unknown role.


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

> The following summary was generated by ChatGPT.

Within the "syncRoleLabelForSinglePod" function, there is a change made to the "getMetaRole" function. Instead of just immediately calling the function, the code now creates an anonymous function that creates a timeout of 2 seconds using a new context, and then calls the "getMetaRole" function before returning the result.

This change was made to ensure that the function didn't hang or cause other issues and still returned results promptly.

## Checklist

- [x] I have written the necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
