### PR TITLE
fix(bug): `kubectl apply --server-side`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ docker-push: ## Push docker image with the manager.
 ##@ Deployment
 
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd | kubectl apply -f -
+	$(KUSTOMIZE) build config/crd | kubectl apply --server-side -f -
 
 uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/crd | kubectl delete -f -
@@ -209,7 +209,7 @@ generate-test-yaml: generate-yaml
 	$(KUSTOMIZE) build config --output config/risingwave-operator-test.yaml
 
 deploy: generate-yaml
-	kubectl apply -f config/risingwave-operator.yaml
+	kubectl apply --server-side -f config/risingwave-operator.yaml
 
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
 	kubectl delete -f config/risingwave-operator.yaml


### PR DESCRIPTION
## What's changed and what's your intention?


Fix 

```
The CustomResourceDefinition "risingwaves.risingwave.risingwavelabs.com" is invalid: metadata.annotations: Too long: must have at most 262144 bytes
```

## Checklist

- [x] I have written the necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

https://linear.app/risingwave-labs/issue/CLOUD-995/operator-deployment-failed-at-head
https://risingwave-labs.slack.com/archives/C04J7UBL5QU/p1677726204294119?thread_ts=1677694554.068959&cid=C04J7UBL5QU
