### PR TITLE
fix: pass total available memory to the compute process

### DIFF
--- a/pkg/factory/risingwave_object_factory.go
+++ b/pkg/factory/risingwave_object_factory.go
@@ -519,14 +519,7 @@ func (f *RisingWaveObjectFactory) argsForCompute(cpuLimit int64, memLimit int64)
 	}
 
 	if memLimit != 0 {
-		// Set to memLimit - 512M if memLimit >= 1G, or 512M when memLimit >= 512M, or just memLimit.
-		totalMemoryBytes := memLimit
-		if totalMemoryBytes >= (int64(1) << 30) {
-			totalMemoryBytes -= 512 << 20
-		} else if totalMemoryBytes >= (512 << 20) {
-			totalMemoryBytes = 512 << 20
-		}
-		args = append(args, "--total-memory-bytes", strconv.FormatInt(totalMemoryBytes, 10))
+		args = append(args, "--total-memory-bytes", strconv.FormatInt(memLimit, 10))
 	}
 
 	return args

--- a/pkg/factory/risingwave_object_factory_testcases_test.go
+++ b/pkg/factory/risingwave_object_factory_testcases_test.go
@@ -2988,19 +2988,19 @@ func computeArgsTestCases() map[string]computeArgsTestCase {
 		"mem-limit-4g": {
 			memLimit: 4 << 30,
 			argsList: [][]string{
-				{"--total-memory-bytes", strconv.Itoa((4 << 30) - (512 << 20))},
+				{"--total-memory-bytes", strconv.Itoa(4 << 30)},
 			},
 		},
 		"mem-limit-1g": {
 			memLimit: 1 << 30,
 			argsList: [][]string{
-				{"--total-memory-bytes", strconv.Itoa((1 << 30) - (512 << 20))},
+				{"--total-memory-bytes", strconv.Itoa(1 << 30)},
 			},
 		},
 		"mem-limit-768m": {
 			memLimit: 768 << 20,
 			argsList: [][]string{
-				{"--total-memory-bytes", strconv.Itoa(512 << 20)},
+				{"--total-memory-bytes", strconv.Itoa(768 << 20)},
 			},
 		},
 		"mem-limit-512m": {
@@ -3020,7 +3020,7 @@ func computeArgsTestCases() map[string]computeArgsTestCase {
 			memLimit: 1 << 30,
 			argsList: [][]string{
 				{"--parallelism", "4"},
-				{"--total-memory-bytes", strconv.Itoa((1 << 30) - (512 << 20))},
+				{"--total-memory-bytes", strconv.Itoa(1 << 30)},
 			},
 		},
 	}


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

Kernel will reserve memory of the min size of `total_available_memory` and `512M`, so this PR aims to
- simplify memory limit computation in RisingWaveObjectFactory by removing conditional statements and always using memLimit. Update corresponding test cases to reflect this change. 


## Checklist

- [x] I have written the necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
