### PR TITLE
refactor(factory): use env options

### DIFF
--- a/config/crd/bases/risingwave.risingwavelabs.com_risingwavepodtemplates.yaml
+++ b/config/crd/bases/risingwave.risingwavelabs.com_risingwavepodtemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
   name: risingwavepodtemplates.risingwave.risingwavelabs.com
 spec:

--- a/config/crd/bases/risingwave.risingwavelabs.com_risingwaves.yaml
+++ b/config/crd/bases/risingwave.risingwavelabs.com_risingwaves.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
   name: risingwaves.risingwave.risingwavelabs.com
 spec:

--- a/config/crd/bases/risingwave.risingwavelabs.com_risingwavescaleviews.yaml
+++ b/config/crd/bases/risingwave.risingwavelabs.com_risingwavescaleviews.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
   name: risingwavescaleviews.risingwave.risingwavelabs.com
 spec:

--- a/config/risingwave-operator-test.yaml
+++ b/config/risingwave-operator-test.yaml
@@ -9,7 +9,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
   name: risingwavepodtemplates.risingwave.risingwavelabs.com
 spec:
@@ -7154,7 +7154,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: risingwave-operator-system/risingwave-operator-serving-cert
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.11.3
   name: risingwaves.risingwave.risingwavelabs.com
 spec:
   conversion:
@@ -18070,7 +18070,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
   name: risingwavescaleviews.risingwave.risingwavelabs.com
 spec:

--- a/config/risingwave-operator.yaml
+++ b/config/risingwave-operator.yaml
@@ -9,7 +9,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
   name: risingwavepodtemplates.risingwave.risingwavelabs.com
 spec:
@@ -7154,7 +7154,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: risingwave-operator-system/risingwave-operator-serving-cert
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.11.3
   name: risingwaves.risingwave.risingwavelabs.com
 spec:
   conversion:
@@ -18070,7 +18070,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
   name: risingwavescaleviews.risingwave.risingwavelabs.com
 spec:

--- a/hack/cspell/dicts/misc.txt
+++ b/hack/cspell/dicts/misc.txt
@@ -49,3 +49,5 @@ Oneof
 protoc
 protoimpl
 protoreflect
+golint
+nolint

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -31,20 +31,6 @@ const (
 )
 
 // =================================================
-// Envs.
-// =================================================
-
-// System reserved envs.
-const (
-	EnvRisingWavePodIp                = "POD_IP"
-	EnvRisingWavePodName              = "POD_NAME"
-	EnvRisingWaveRustBacktrace        = "RUST_BACKTRACE"
-	EnvRisingWaveWorkerThreads        = "RW_WORKER_THREADS"
-	EnvRisingWaveConnectorRpcEndPoint = "RW_CONNECTOR_RPC_ENDPOINT"
-	EnvRisingWaveJavaOpts             = "JAVA_OPTS"
-)
-
-// =================================================
 // Annotations.
 // =================================================
 

--- a/pkg/factory/envs/risingwave.go
+++ b/pkg/factory/envs/risingwave.go
@@ -37,7 +37,7 @@ const (
 	RWBackend                = "RW_BACKEND"
 	RWMetaAddr               = "RW_META_ADDR"
 	RWMetaAddrLegacy         = "RW_META_ADDRESS" // Will deprecate soon.
-	RWMetricLevel            = "RW_METRIC_LEVEL"
+	RWMetricsLevel           = "RW_METRICS_LEVEL"
 	RWPrometheusListenerAddr = "RW_PROMETHEUS_LISTENER_ADDR"
 	RWParallelism            = "RW_PARALLELISM"
 	RWTotalMemoryBytes       = "RW_TOTAL_MEMORY_BYTES"

--- a/pkg/factory/envs/risingwave.go
+++ b/pkg/factory/envs/risingwave.go
@@ -1,0 +1,81 @@
+// Copyright 2023 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package envs
+
+// cspell:disable
+
+// Environment variables to pass options to the RisingWave process and control the behavior.
+const (
+	RustBacktrace = "RUST_BACKTRACE"
+	JavaOpts      = "JAVA_OPTS"
+
+	RWListenAddr             = "RW_LISTEN_ADDR"
+	RWAdvertiseAddr          = "RW_ADVERTISE_ADDR"
+	RWDashboardHost          = "RW_DASHBOARD_HOST"
+	RWPrometheusHost         = "RW_PROMETHEUS_HOST"
+	RWEtcdEndpoints          = "RW_ETCD_ENDPOINTS"
+	RWEtcdAuth               = "RW_ETCD_AUTH"
+	RWEtcdUsername           = "RW_ETCD_USERNAME"
+	RWEtcdPassword           = "RW_ETCD_PASSWORD"
+	RWConfigPath             = "RW_CONFIG_PATH"
+	RWStateStore             = "RW_STATE_STORE"
+	RWDataDirectory          = "RW_DATA_DIRECTORY"
+	RWWorkerThreads          = "RW_WORKER_THREADS"
+	RWConnectorRPCEndPoint   = "RW_CONNECTOR_RPC_ENDPOINT"
+	RWBackend                = "RW_BACKEND"
+	RWMetaAddr               = "RW_META_ADDR"
+	RWMetaAddrLegacy         = "RW_META_ADDRESS" // Will deprecate soon.
+	RWMetricLevel            = "RW_METRIC_LEVEL"
+	RWPrometheusListenerAddr = "RW_PROMETHEUS_LISTENER_ADDR"
+	RWParallelism            = "RW_PARALLELISM"
+	RWTotalMemoryBytes       = "RW_TOTAL_MEMORY_BYTES"
+)
+
+// MinIO.
+const (
+	MinIOEndpoint = "MINIO_ENDPOINT"
+	MinIOBucket   = "MINIO_BUCKET"
+	MinIOUsername = "MINIO_USERNAME"
+	MinIOPassword = "MINIO_PASSWORD"
+)
+
+// etcd.
+const (
+	EtcdUsernameLegacy = "ETCD_USERNAME"
+	EtcdPasswordLegacy = "ETCD_PASSWORD"
+)
+
+// AWS S3.
+const (
+	AWSRegion              = "AWS_REGION"
+	AWSAccessKeyID         = "AWS_ACCESS_KEY_ID"
+	AWSSecretAccessKey     = "AWS_SECRET_ACCESS_KEY"
+	AWSS3Bucket            = "AWS_S3_BUCKET"
+	AWSEC2MetadataDisabled = "AWS_EC2_METADATA_DISABLED"
+)
+
+// S3 compatible.
+const (
+	S3CompatibleRegion          = "S3_COMPATIBLE_REGION"
+	S3CompatibleBucket          = "S3_COMPATIBLE_BUCKET"
+	S3CompatibleAccessKeyID     = "S3_COMPATIBLE_ACCESS_KEY_ID"
+	S3CompatibleSecretAccessKey = "S3_COMPATIBLE_SECRET_ACCESS_KEY"
+	S3CompatibleEndpoint        = "S3_COMPATIBLE_ENDPOINT"
+)
+
+const (
+	// GoogleApplicationCredentials for GCS service.
+	GoogleApplicationCredentials = "GOOGLE_APPLICATION_CREDENTIALS"
+)

--- a/pkg/factory/envs/system.go
+++ b/pkg/factory/envs/system.go
@@ -1,0 +1,21 @@
+// Copyright 2023 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package envs
+
+// System reserved envs.
+const (
+	PodIP   = "POD_IP"
+	PodName = "POD_NAME"
+)

--- a/pkg/factory/risingwave_object_factory.go
+++ b/pkg/factory/risingwave_object_factory.go
@@ -530,7 +530,7 @@ func (f *RisingWaveObjectFactory) envsForFrontendArgs() []corev1.EnvVar {
 			Value: fmt.Sprintf("load-balance+http://%s:%d", f.componentName(consts.ComponentMeta, ""), metaPorts.ServicePort),
 		},
 		{
-			Name:  envs.RWMetricLevel,
+			Name:  envs.RWMetricsLevel,
 			Value: "1",
 		},
 		{
@@ -567,7 +567,7 @@ func (f *RisingWaveObjectFactory) envsForComputeArgs(cpuLimit int64, memLimit in
 			Value: fmt.Sprintf("load-balance+http://%s:%d", f.componentName(consts.ComponentMeta, ""), metaPorts.ServicePort),
 		},
 		{
-			Name:  envs.RWMetricLevel,
+			Name:  envs.RWMetricsLevel,
 			Value: "1",
 		},
 		{
@@ -623,7 +623,7 @@ func (f *RisingWaveObjectFactory) envsForCompactorArgs() []corev1.EnvVar {
 			Value: fmt.Sprintf("load-balance+http://%s:%d", f.componentName(consts.ComponentMeta, ""), metaPorts.ServicePort),
 		},
 		{
-			Name:  envs.RWMetricLevel,
+			Name:  envs.RWMetricsLevel,
 			Value: "1",
 		},
 	}

--- a/pkg/factory/risingwave_object_factory_common_test.go
+++ b/pkg/factory/risingwave_object_factory_common_test.go
@@ -359,6 +359,7 @@ func newPodTemplate(patches ...func(t *risingwavev1alpha1.RisingWavePodTemplateS
 	return t
 }
 
+//nolint:golint,unused
 func containsStringSlice(a, b []string) bool {
 	if len(a) < len(b) {
 		return false
@@ -374,6 +375,7 @@ func containsStringSlice(a, b []string) bool {
 	return false
 }
 
+//nolint:golint,unused
 func containsSlice[T comparable](a, b []T) bool {
 	for i := 0; i <= len(a)-len(b); i++ {
 		match := true

--- a/pkg/factory/risingwave_object_factory_predicate_test.go
+++ b/pkg/factory/risingwave_object_factory_predicate_test.go
@@ -1012,12 +1012,6 @@ func serviceMetadataPredicates() []predicate[*corev1.Service, serviceMetadataTes
 func objectStorageStatefulsetPredicates() []predicate[*appsv1.StatefulSet, objectStoragesTestCase] {
 	return []predicate[*appsv1.StatefulSet, objectStoragesTestCase]{
 		{
-			Name: "hummock-args-match",
-			Fn: func(obj *appsv1.StatefulSet, tc objectStoragesTestCase) bool {
-				return lo.Contains(obj.Spec.Template.Spec.Containers[0].Args, tc.hummockArg)
-			},
-		},
-		{
 			Name: "env-vars-contains",
 			Fn: func(obj *appsv1.StatefulSet, tc objectStoragesTestCase) bool {
 				return listContainsByKey(obj.Spec.Template.Spec.Containers[0].Env, tc.envs, func(t *corev1.EnvVar) string { return t.Name }, deepEqual[corev1.EnvVar])
@@ -1059,12 +1053,6 @@ func configMapPredicates() []predicate[*corev1.ConfigMap, configMapTestCase] {
 
 func metaStoragePredicates() []predicate[*appsv1.StatefulSet, metaStorageTestCase] {
 	return []predicate[*appsv1.StatefulSet, metaStorageTestCase]{
-		{
-			Name: "args-match",
-			Fn: func(obj *appsv1.StatefulSet, tc metaStorageTestCase) bool {
-				return containsStringSlice(obj.Spec.Template.Spec.Containers[0].Args, tc.args)
-			},
-		},
 		{
 			Name: "env-vars-contains",
 			Fn: func(obj *appsv1.StatefulSet, tc metaStorageTestCase) bool {

--- a/pkg/factory/risingwave_object_factory_test.go
+++ b/pkg/factory/risingwave_object_factory_test.go
@@ -17,7 +17,6 @@
 package factory
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -436,7 +435,7 @@ func Test_RisingWaveObjectFactory_InheritLabels(t *testing.T) {
 }
 
 func TestRisingWaveObjectFactory_ComputeArgs(t *testing.T) {
-	for name, tc := range computeArgsTestCases() {
+	for name, tc := range computeEnvsTestCases() {
 		t.Run(name, func(t *testing.T) {
 			factory := NewRisingWaveObjectFactory(&risingwavev1alpha1.RisingWave{
 				Spec: risingwavev1alpha1.RisingWaveSpec{
@@ -447,12 +446,11 @@ func TestRisingWaveObjectFactory_ComputeArgs(t *testing.T) {
 					},
 				},
 			}, nil, "")
-			args := factory.argsForCompute(tc.cpuLimit, tc.memLimit)
+			envs := factory.envsForComputeArgs(tc.cpuLimit, tc.memLimit)
 
-			for _, expectArgs := range tc.argsList {
-				if !containsSlice(args, expectArgs) {
-					t.Errorf("Args not expected, expects \"%s\", but is \"%s\"",
-						strings.Join(expectArgs, " "), strings.Join(args, " "))
+			for _, expectEnv := range tc.envList {
+				if !listContainsByKey(envs, []corev1.EnvVar{expectEnv}, func(t *corev1.EnvVar) string { return t.Name }, deepEqual[corev1.EnvVar]) {
+					t.Errorf("Env not found or value not expected, expects \"%s\"", testutils.JSONMustPrettyPrint(expectEnv))
 				}
 			}
 		})

--- a/pkg/factory/risingwave_object_factory_testcases_test.go
+++ b/pkg/factory/risingwave_object_factory_testcases_test.go
@@ -2482,7 +2482,6 @@ func serviceMetadataTestCases() map[string]serviceMetadataTestCase {
 type objectStoragesTestCase struct {
 	baseTestCase
 	objectStorage risingwavev1alpha1.RisingWaveObjectStorage
-	hummockArg    string
 	envs          []corev1.EnvVar
 }
 
@@ -2492,7 +2491,12 @@ func objectStorageTestCases() map[string]objectStoragesTestCase {
 			objectStorage: risingwavev1alpha1.RisingWaveObjectStorage{
 				Memory: pointer.Bool(true),
 			},
-			hummockArg: "hummock+memory",
+			envs: []corev1.EnvVar{
+				{
+					Name:  "RW_STATE_STORE",
+					Value: "hummock+memory",
+				},
+			},
 		},
 		"minio": {
 			objectStorage: risingwavev1alpha1.RisingWaveObjectStorage{
@@ -2502,8 +2506,11 @@ func objectStorageTestCases() map[string]objectStoragesTestCase {
 					Bucket:   "minio-hummock01",
 				},
 			},
-			hummockArg: "hummock+minio://$(MINIO_USERNAME):$(MINIO_PASSWORD)@minio-endpoint:1234/minio-hummock01",
 			envs: []corev1.EnvVar{
+				{
+					Name:  "RW_STATE_STORE",
+					Value: "hummock+minio://$(MINIO_USERNAME):$(MINIO_PASSWORD)@minio-endpoint:1234/minio-hummock01",
+				},
 				{
 					Name: "MINIO_USERNAME",
 					ValueFrom: &corev1.EnvVarSource{
@@ -2535,8 +2542,11 @@ func objectStorageTestCases() map[string]objectStoragesTestCase {
 					Bucket: "s3-hummock01",
 				},
 			},
-			hummockArg: "hummock+s3://s3-hummock01",
 			envs: []corev1.EnvVar{
+				{
+					Name:  "RW_STATE_STORE",
+					Value: "hummock+s3://s3-hummock01",
+				},
 				{
 					Name:  "AWS_S3_BUCKET",
 					Value: "s3-hummock01",
@@ -2584,8 +2594,10 @@ func objectStorageTestCases() map[string]objectStoragesTestCase {
 					Root:                "gcs-root",
 				},
 			},
-			hummockArg: "hummock+gcs://gcs-bucket@gcs-root",
-			envs:       []corev1.EnvVar{},
+			envs: []corev1.EnvVar{{
+				Name:  "RW_STATE_STORE",
+				Value: "hummock+gcs://gcs-bucket@gcs-root",
+			}},
 		},
 		"gcs-secret": {
 			objectStorage: risingwavev1alpha1.RisingWaveObjectStorage{
@@ -2596,8 +2608,11 @@ func objectStorageTestCases() map[string]objectStoragesTestCase {
 					Root:                "gcs-root",
 				},
 			},
-			hummockArg: "hummock+gcs://gcs-bucket@gcs-root",
 			envs: []corev1.EnvVar{
+				{
+					Name:  "RW_STATE_STORE",
+					Value: "hummock+gcs://gcs-bucket@gcs-root",
+				},
 				{
 					Name: "GOOGLE_APPLICATION_CREDENTIALS",
 					ValueFrom: &corev1.EnvVarSource{
@@ -2618,8 +2633,11 @@ func objectStorageTestCases() map[string]objectStoragesTestCase {
 					Bucket: "s3-hummock01",
 				},
 			},
-			hummockArg: "hummock+s3-compatible://s3-hummock01",
 			envs: []corev1.EnvVar{
+				{
+					Name:  "RW_STATE_STORE",
+					Value: "hummock+s3-compatible://s3-hummock01",
+				},
 				{
 					Name:  "S3_COMPATIBLE_BUCKET",
 					Value: "s3-hummock01",
@@ -2671,8 +2689,11 @@ func objectStorageTestCases() map[string]objectStoragesTestCase {
 					InternalEndpoint: true,
 				},
 			},
-			hummockArg: "hummock+s3-compatible://s3-hummock01",
 			envs: []corev1.EnvVar{
+				{
+					Name:  "RW_STATE_STORE",
+					Value: "hummock+s3-compatible://s3-hummock01",
+				},
 				{
 					Name:  "S3_COMPATIBLE_BUCKET",
 					Value: "s3-hummock01",
@@ -2724,8 +2745,11 @@ func objectStorageTestCases() map[string]objectStoragesTestCase {
 					Region: "cn-hangzhou",
 				},
 			},
-			hummockArg: "hummock+s3-compatible://s3-hummock01",
 			envs: []corev1.EnvVar{
+				{
+					Name:  "RW_STATE_STORE",
+					Value: "hummock+s3-compatible://s3-hummock01",
+				},
 				{
 					Name:  "S3_COMPATIBLE_BUCKET",
 					Value: "s3-hummock01",
@@ -2770,8 +2794,11 @@ func objectStorageTestCases() map[string]objectStoragesTestCase {
 					Endpoint: "oss-cn-hangzhou.aliyuncs.com",
 				},
 			},
-			hummockArg: "hummock+s3-compatible://s3-hummock01",
 			envs: []corev1.EnvVar{
+				{
+					Name:  "RW_STATE_STORE",
+					Value: "hummock+s3-compatible://s3-hummock01",
+				},
 				{
 					Name:  "S3_COMPATIBLE_BUCKET",
 					Value: "s3-hummock01",
@@ -2824,8 +2851,11 @@ func objectStorageTestCases() map[string]objectStoragesTestCase {
 					VirtualHostedStyle: true,
 				},
 			},
-			hummockArg: "hummock+s3-compatible://s3-hummock01",
 			envs: []corev1.EnvVar{
+				{
+					Name:  "RW_STATE_STORE",
+					Value: "hummock+s3-compatible://s3-hummock01",
+				},
 				{
 					Name:  "S3_COMPATIBLE_BUCKET",
 					Value: "s3-hummock01",
@@ -2877,8 +2907,11 @@ func objectStorageTestCases() map[string]objectStoragesTestCase {
 					Region: "ap-southeast-1",
 				},
 			},
-			hummockArg: "hummock+s3://s3-hummock01",
 			envs: []corev1.EnvVar{
+				{
+					Name:  "RW_STATE_STORE",
+					Value: "hummock+s3://s3-hummock01",
+				},
 				{
 					Name:  "AWS_S3_BUCKET",
 					Value: "s3-hummock01",
@@ -2918,8 +2951,11 @@ func objectStorageTestCases() map[string]objectStoragesTestCase {
 					Endpoint: "s3.${REGION}.amazonaws.com",
 				},
 			},
-			hummockArg: "hummock+s3-compatible://s3-hummock01",
 			envs: []corev1.EnvVar{
+				{
+					Name:  "RW_STATE_STORE",
+					Value: "hummock+s3-compatible://s3-hummock01",
+				},
 				{
 					Name:  "S3_COMPATIBLE_ENDPOINT",
 					Value: "https://s3.$(S3_COMPATIBLE_REGION).amazonaws.com",
@@ -2933,8 +2969,11 @@ func objectStorageTestCases() map[string]objectStoragesTestCase {
 					Endpoint: "${BUCKET}.s3.${REGION}.amazonaws.com",
 				},
 			},
-			hummockArg: "hummock+s3-compatible://s3-hummock01",
 			envs: []corev1.EnvVar{
+				{
+					Name:  "RW_STATE_STORE",
+					Value: "hummock+s3-compatible://s3-hummock01",
+				},
 				{
 					Name:  "S3_COMPATIBLE_ENDPOINT",
 					Value: "https://$(S3_COMPATIBLE_BUCKET).s3.$(S3_COMPATIBLE_REGION).amazonaws.com",
@@ -2948,8 +2987,10 @@ func objectStorageTestCases() map[string]objectStoragesTestCase {
 					Root:     "root",
 				},
 			},
-			hummockArg: "hummock+hdfs://name-node@root",
-			envs:       []corev1.EnvVar{},
+			envs: []corev1.EnvVar{{
+				Name:  "RW_STATE_STORE",
+				Value: "hummock+hdfs://name-node@root",
+			}},
 		},
 	}
 }
@@ -2973,54 +3014,78 @@ func configMapTestCases() map[string]configMapTestCase {
 type computeArgsTestCase struct {
 	cpuLimit int64
 	memLimit int64
-	argsList [][]string
+	envList  []corev1.EnvVar
 }
 
-func computeArgsTestCases() map[string]computeArgsTestCase {
+func computeEnvsTestCases() map[string]computeArgsTestCase {
 	return map[string]computeArgsTestCase{
 		"empty-limits": {},
 		"cpu-limit-4": {
 			cpuLimit: 4,
-			argsList: [][]string{
-				{"--parallelism", "4"},
+			envList: []corev1.EnvVar{
+				{
+					Name:  "RW_PARALLELISM",
+					Value: "4",
+				},
 			},
 		},
 		"mem-limit-4g": {
 			memLimit: 4 << 30,
-			argsList: [][]string{
-				{"--total-memory-bytes", strconv.Itoa(4 << 30)},
+			envList: []corev1.EnvVar{
+				{
+					Name:  "RW_TOTAL_MEMORY_BYTES",
+					Value: strconv.Itoa(4 << 30),
+				},
 			},
 		},
 		"mem-limit-1g": {
 			memLimit: 1 << 30,
-			argsList: [][]string{
-				{"--total-memory-bytes", strconv.Itoa(1 << 30)},
+			envList: []corev1.EnvVar{
+				{
+					Name:  "RW_TOTAL_MEMORY_BYTES",
+					Value: strconv.Itoa(1 << 30),
+				},
 			},
 		},
 		"mem-limit-768m": {
 			memLimit: 768 << 20,
-			argsList: [][]string{
-				{"--total-memory-bytes", strconv.Itoa(768 << 20)},
+			envList: []corev1.EnvVar{
+				{
+					Name:  "RW_TOTAL_MEMORY_BYTES",
+					Value: strconv.Itoa(768 << 20),
+				},
 			},
 		},
 		"mem-limit-512m": {
 			memLimit: 512 << 20,
-			argsList: [][]string{
-				{"--total-memory-bytes", strconv.Itoa(512 << 20)},
+			envList: []corev1.EnvVar{
+				{
+					Name:  "RW_TOTAL_MEMORY_BYTES",
+					Value: strconv.Itoa(512 << 20),
+				},
 			},
 		},
 		"mem-limit-256m": {
 			memLimit: 256 << 20,
-			argsList: [][]string{
-				{"--total-memory-bytes", strconv.Itoa(256 << 20)},
+			envList: []corev1.EnvVar{
+				{
+					Name:  "RW_TOTAL_MEMORY_BYTES",
+					Value: strconv.Itoa(256 << 20),
+				},
 			},
 		},
 		"cpu-and-mem": {
 			cpuLimit: 4,
 			memLimit: 1 << 30,
-			argsList: [][]string{
-				{"--parallelism", "4"},
-				{"--total-memory-bytes", strconv.Itoa(1 << 30)},
+			envList: []corev1.EnvVar{
+				{
+					Name:  "RW_PARALLELISM",
+					Value: "4",
+				},
+				{
+					Name:  "RW_TOTAL_MEMORY_BYTES",
+					Value: strconv.Itoa(1 << 30),
+				},
 			},
 		},
 	}
@@ -3080,7 +3145,6 @@ func inheritedLabelsTestCases() map[string]inheritedLabelsTestCase {
 
 type metaStorageTestCase struct {
 	metaStorage risingwavev1alpha1.RisingWaveMetaStorage
-	args        []string
 	envs        []corev1.EnvVar
 }
 
@@ -3090,8 +3154,11 @@ func metaStorageTestCases() map[string]metaStorageTestCase {
 			metaStorage: risingwavev1alpha1.RisingWaveMetaStorage{
 				Memory: pointer.Bool(true),
 			},
-			args: []string{
-				"--backend", "mem",
+			envs: []corev1.EnvVar{
+				{
+					Name:  "RW_BACKEND",
+					Value: "mem",
+				},
 			},
 		},
 		"etcd-no-auth": {
@@ -3100,8 +3167,15 @@ func metaStorageTestCases() map[string]metaStorageTestCase {
 					Endpoint: "etcd:1234",
 				},
 			},
-			args: []string{
-				"--backend", "etcd", "--etcd-endpoints", "etcd:1234",
+			envs: []corev1.EnvVar{
+				{
+					Name:  "RW_BACKEND",
+					Value: "etcd",
+				},
+				{
+					Name:  "RW_ETCD_ENDPOINTS",
+					Value: "etcd:1234",
+				},
 			},
 		},
 		"etcd-auth": {
@@ -3111,10 +3185,15 @@ func metaStorageTestCases() map[string]metaStorageTestCase {
 					Secret:   "etcd-credentials",
 				},
 			},
-			args: []string{
-				"--backend", "etcd", "--etcd-endpoints", "etcd:1234", "--etcd-auth",
-			},
 			envs: []corev1.EnvVar{
+				{
+					Name:  "RW_BACKEND",
+					Value: "etcd",
+				},
+				{
+					Name:  "RW_ETCD_ENDPOINTS",
+					Value: "etcd:1234",
+				},
 				{
 					Name: "RW_ETCD_USERNAME",
 					ValueFrom: &corev1.EnvVarSource{

--- a/pkg/webhook/risingwave_validating_webhook.go
+++ b/pkg/webhook/risingwave_validating_webhook.go
@@ -22,7 +22,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/risingwavelabs/risingwave-operator/pkg/consts"
+	"github.com/risingwavelabs/risingwave-operator/pkg/factory/envs"
 
 	"github.com/distribution/distribution/reference"
 	"github.com/samber/lo"
@@ -51,12 +51,12 @@ func isImageValid(image string) bool {
 }
 
 var systemEnv = map[string]bool{
-	consts.EnvRisingWavePodIp:                true,
-	consts.EnvRisingWavePodName:              true,
-	consts.EnvRisingWaveRustBacktrace:        true,
-	consts.EnvRisingWaveWorkerThreads:        true,
-	consts.EnvRisingWaveConnectorRpcEndPoint: true,
-	consts.EnvRisingWaveJavaOpts:             true,
+	envs.PodIP:                  true,
+	envs.PodName:                true,
+	envs.RustBacktrace:          true,
+	envs.RWWorkerThreads:        true,
+	envs.RWConnectorRPCEndPoint: true,
+	envs.JavaOpts:               true,
 }
 
 func (v *RisingWaveValidatingWebhook) validateGroupTemplate(path *field.Path, groupTemplate *risingwavev1alpha1.RisingWaveComponentGroupTemplate, isOpenKruiseEnabled bool) field.ErrorList {

--- a/test/e2e/tests/risingwave/meta.sh
+++ b/test/e2e/tests/risingwave/meta.sh
@@ -86,7 +86,7 @@ function risingwave::utils::is_meta_setup_valid() {
   fi
 
   if [ "$(echo "$meta_leaders" | wc -l)" -gt 1 ]; then
-    logging::error "More than one meta leader node found"
+    logging::warn "More than one meta leader node found"
     return 1
   fi
   return 0


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Use env-based options to start RisingWave processes. Deprecate the CLI arguments way.
- Move env name constants to a separate package `pkg/factory/envs`.
- Update the tests accordingly.

In this way, backward-compatibility is way easier to maintain because naturally the environment variables require a semantic of optional. For example, there are two environment variables representing the same option but exclusively used by different versions:
- `META_ADDRESS` by `v0.1.17` only
- `META_ADDR` by `v0.1.18-rc` and after versions

The operator can now deploy both versions without worrying of incompatibilities. The PR passed all e2e tests locally.

## Checklist

- [x] I have written the necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
