### PR TITLE
test: support hdfs e2e testcase

### DIFF
--- a/test/e2e/testenv/lib.sh
+++ b/test/e2e/testenv/lib.sh
@@ -164,7 +164,7 @@ _RISINGWAVE_OPERATOR_ENABLE_OPENKRUISE_PATCH_FILE="$(dirname "${BASH_SOURCE[0]}"
 
 function testenv::k8s::risingwave_operator::install() {
   testenv::k8s::load_docker_image "${_RISINGWAVE_OPERATOR_TEST_IMAGE}"
-  shell::run k8s::kubectl apply -f "${_RISINGWAVE_OPERATOR_MANIFEST_FOR_TEST_PATH}"
+  shell::run k8s::kubectl apply --server-side -f "${_RISINGWAVE_OPERATOR_MANIFEST_FOR_TEST_PATH}"
 
   # shellcheck disable=SC2034
   local KUBECTL_NAMESPACE="${_RISINGWAVE_OPERATOR_NAMESPACE}"
@@ -209,7 +209,9 @@ function testenv::setup() {
   testenv::k8s::cert_manager::install || return $?
   logging::info "Installing risingwave-operator..."
   testenv::k8s::risingwave_operator::install || return $?
+  logging::info "Finish installing risingwave-operator..."
 
+  logging::info "Installing openkruise..."
   testenv::k8s::install_openkruise
   logging::info "Test env all set!"
 }

--- a/test/e2e/tests/risingwave/manifests/storages/object-hdfs.yaml
+++ b/test/e2e/tests/risingwave/manifests/storages/object-hdfs.yaml
@@ -193,4 +193,4 @@ spec:
     object:
       hdfs:
         nameNode: hdfs-master
-        root: /root
+        root: /

--- a/test/e2e/tests/risingwave/manifests/storages/object-hdfs.yaml
+++ b/test/e2e/tests/risingwave/manifests/storages/object-hdfs.yaml
@@ -35,13 +35,6 @@ spec:
     - name: hdfs-master
       image: kubeguide/hadoop:latest
       imagePullPolicy: IfNotPresent
-      resources:
-        limits:
-          memory: 512Mi
-          cpu: "1"
-        requests:
-          memory: 256Mi
-          cpu: "0.2"
       ports:
         - containerPort: 9000
         - containerPort: 50070    
@@ -71,13 +64,6 @@ spec:
     - name: hadoop-datanode-1
       image: kubeguide/hadoop:latest
       imagePullPolicy: IfNotPresent
-      resources:
-        limits:
-          memory: 512Mi
-          cpu: "1"
-        requests:
-          memory: 256Mi
-          cpu: "0.2"
       ports:
         - containerPort: 9000
         - containerPort: 50070    
@@ -127,13 +113,6 @@ spec:
     - name: yarn-master
       image: kubeguide/hadoop:latest
       imagePullPolicy: IfNotPresent
-      resources:
-        limits:
-          memory: 512Mi
-          cpu: "1"
-        requests:
-          memory: 256Mi
-          cpu: "0.2"
       ports:
         - containerPort: 9000
         - containerPort: 50070    
@@ -174,13 +153,6 @@ spec:
     - name: yarn-node-1
       image: kubeguide/hadoop:latest
       imagePullPolicy: IfNotPresent
-      resources:
-        limits:
-          memory: 512Mi
-          cpu: "1"
-        requests:
-          memory: 256Mi
-          cpu: "0.2"
       ports:
         - containerPort: 8040
         - containerPort: 8041   

--- a/test/e2e/tests/risingwave/manifests/storages/object-hdfs.yaml
+++ b/test/e2e/tests/risingwave/manifests/storages/object-hdfs.yaml
@@ -1,0 +1,224 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-hadoop-conf
+  namespace: ${E2E_NAMESPACE}
+data:
+  HDFS_MASTER_SERVICE: hadoop-hdfs-master
+  HDOOP_YARN_MASTER: hadoop-yarn-master
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hadoop-hdfs-master
+spec:
+  type: NodePort
+  selector:
+    app: hdfs-master
+  ports:
+    - name: rpc
+      port: 9000
+      targetPort: 9000
+    - name: http
+      port: 50070
+      targetPort: 50070
+      nodePort: 32007
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hdfs-master
+  labels:
+    app: hdfs-master
+spec:
+  containers:
+    - name: hdfs-master
+      image: kubeguide/hadoop:latest
+      imagePullPolicy: IfNotPresent
+      resources:
+        limits:
+          memory: 512Mi
+          cpu: "1"
+        requests:
+          memory: 256Mi
+          cpu: "0.2"
+      ports:
+        - containerPort: 9000
+        - containerPort: 50070    
+      env:
+        - name: HADOOP_NODE_TYPE
+          value: namenode
+        - name: HDFS_MASTER_SERVICE
+          valueFrom:
+            configMapKeyRef:
+              name: kube-hadoop-conf
+              key: HDFS_MASTER_SERVICE
+        - name: HDOOP_YARN_MASTER
+          valueFrom:
+            configMapKeyRef:
+              name: kube-hadoop-conf
+              key: HDOOP_YARN_MASTER
+  restartPolicy: Always
+---
+apiVersion: v1
+kind: Pod
+metadata:
+    name: hadoop-datanode-1
+    labels:
+      app: hadoop-datanode-1
+spec:
+  containers:
+    - name: hadoop-datanode-1
+      image: kubeguide/hadoop:latest
+      imagePullPolicy: IfNotPresent
+      resources:
+        limits:
+          memory: 512Mi
+          cpu: "1"
+        requests:
+          memory: 256Mi
+          cpu: "0.2"
+      ports:
+        - containerPort: 9000
+        - containerPort: 50070    
+      env:
+        - name: HADOOP_NODE_TYPE
+          value: datanode
+        - name: HDFS_MASTER_SERVICE
+          valueFrom:
+            configMapKeyRef:
+              name: kube-hadoop-conf
+              key: HDFS_MASTER_SERVICE
+        - name: HDOOP_YARN_MASTER
+          valueFrom:
+            configMapKeyRef:
+              name: kube-hadoop-conf
+              key: HDOOP_YARN_MASTER        
+  restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hadoop-yarn-master
+spec:
+  type: NodePort
+  selector:
+    app: yarn-master
+  ports:
+     - name: "8030"       
+       port: 8030
+     - name: "8031"     
+       port: 8031
+     - name: "8032"
+       port: 8032     
+     - name: http
+       port: 8088
+       targetPort: 8088
+       nodePort: 32088
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: yarn-master
+  labels:
+    app: yarn-master
+spec:
+  containers:
+    - name: yarn-master
+      image: kubeguide/hadoop:latest
+      imagePullPolicy: IfNotPresent
+      resources:
+        limits:
+          memory: 512Mi
+          cpu: "1"
+        requests:
+          memory: 256Mi
+          cpu: "0.2"
+      ports:
+        - containerPort: 9000
+        - containerPort: 50070    
+      env:
+        - name: HADOOP_NODE_TYPE
+          value: resourceman
+        - name: HDFS_MASTER_SERVICE
+          valueFrom:
+            configMapKeyRef:
+              name: kube-hadoop-conf
+              key: HDFS_MASTER_SERVICE
+        - name: HDOOP_YARN_MASTER
+          valueFrom:
+            configMapKeyRef:
+              name: kube-hadoop-conf
+              key: HDOOP_YARN_MASTER          
+  restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: yarn-node-1
+spec:
+  clusterIP: None
+  selector:
+    app: yarn-node-1
+  ports:
+     - port: 8040
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: yarn-node-1
+  labels:
+    app: yarn-node-1
+spec:
+  containers:
+    - name: yarn-node-1
+      image: kubeguide/hadoop:latest
+      imagePullPolicy: IfNotPresent
+      resources:
+        limits:
+          memory: 512Mi
+          cpu: "1"
+        requests:
+          memory: 256Mi
+          cpu: "0.2"
+      ports:
+        - containerPort: 8040
+        - containerPort: 8041   
+        - containerPort: 8042        
+      env:
+        - name: HADOOP_NODE_TYPE
+          value: yarnnode
+        - name: HDFS_MASTER_SERVICE
+          valueFrom:
+            configMapKeyRef:
+              name: kube-hadoop-conf
+              key: HDFS_MASTER_SERVICE
+        - name: HDOOP_YARN_MASTER
+          valueFrom:
+            configMapKeyRef:
+              name: kube-hadoop-conf
+              key: HDOOP_YARN_MASTER          
+  restartPolicy: Always
+
+---
+apiVersion: risingwave.risingwavelabs.com/v1alpha1
+kind: RisingWave
+metadata:
+  name: ${E2E_RISINGWAVE_NAME}
+  namespace: ${E2E_NAMESPACE}
+spec:
+  global:
+    image: ${E2E_RISINGWAVE_IMAGE}
+    imagePullPolicy: IfNotPresent
+    replicas:
+      meta: 1
+      frontend: 1
+      compute: 1
+      compactor: 1
+  storages:
+    meta:
+      memory: true
+    object:
+      hdfs:
+        nameNode: hdfs-master
+        root: /root

--- a/test/e2e/tests/risingwave/tests.sh
+++ b/test/e2e/tests/risingwave/tests.sh
@@ -156,6 +156,10 @@ function test::run::risingwave::storage_support::object_minio() {
   test::risingwave::storage_support::_run_with_manifest storages/object-minio.yaml
 }
 
+function test::run::risingwave::storage_support::object_hdfs() {
+  test::risingwave::storage_support::_run_with_manifest storages/object-hdfs.yaml
+}
+
 function test::run::risingwave::openkruise_integration() {
   logging::info "Starting RisingWave..."
   if ! test::risingwave::start storages/meta-memory-object-memory.yaml; then


### PR DESCRIPTION
## What's changed and what's your intention?
Add end-to-end test for HDFS in the operator.
Currently, the rw are not supporting hdfs by default, so need to build an image with HDFS feature opening. But currently, there is some bug in the hummock HDFS storage code. Congy is focusing on solving it. 

## Checklist

- [ ] I have written the necessary docs and comments
- [ ] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
