### PR TITLE
fix(metrics): add metrics port env for compute node(CLOUD-1211)

### DIFF
--- a/pkg/factory/risingwave_object_factory.go
+++ b/pkg/factory/risingwave_object_factory.go
@@ -574,6 +574,10 @@ func (f *RisingWaveObjectFactory) envsForComputeArgs(cpuLimit int64, memLimit in
 			Name:  envs.RWConnectorRPCEndPoint,
 			Value: fmt.Sprintf("%s:%d", f.componentName(consts.ComponentConnector, ""), connectorPorts.ServicePort),
 		},
+		{
+			Name:  envs.RWPrometheusListenerAddr,
+			Value: fmt.Sprintf("0.0.0.0:%d", computePorts.MetricsPort),
+		},
 	}
 
 	if cpuLimit != 0 {


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

As the title.


## Checklist

- [x] I have written the necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
https://linear.app/risingwave-labs/issue/CLOUD-1211/bug-not-getting-any-analytics-datacpumemorythroughput-from-api-for-all