### PR TITLE
feat: add a new field dataDirectory to specify the directory directly

### DIFF
--- a/apis/risingwave/v1alpha1/risingwave_types.go
+++ b/apis/risingwave/v1alpha1/risingwave_types.go
@@ -511,6 +511,9 @@ type RisingWaveObjectStorageHDFS struct {
 
 // RisingWaveObjectStorage is the object storage for compute and compactor components.
 type RisingWaveObjectStorage struct {
+	// DataDirectory is the directory to store the data in the object storage. It is an optional field.
+	DataDirectory string `json:"dataDirectory,omitempty"`
+
 	// Memory indicates to store the data in memory. It's only for test usage and strongly discouraged to
 	// be used in production.
 	// +optional

--- a/config/crd/bases/risingwave.risingwavelabs.com_risingwaves.yaml
+++ b/config/crd/bases/risingwave.risingwavelabs.com_risingwaves.yaml
@@ -10200,6 +10200,10 @@ spec:
                         - bucket
                         - secret
                         type: object
+                      dataDirectory:
+                        description: DataDirectory is the directory to store the data
+                          in the object storage. It is an optional field.
+                        type: string
                       hdfs:
                         description: HDFS storage spec.
                         properties:

--- a/config/risingwave-operator-test.yaml
+++ b/config/risingwave-operator-test.yaml
@@ -17360,6 +17360,10 @@ spec:
                         - bucket
                         - secret
                         type: object
+                      dataDirectory:
+                        description: DataDirectory is the directory to store the data
+                          in the object storage. It is an optional field.
+                        type: string
                       hdfs:
                         description: HDFS storage spec.
                         properties:

--- a/config/risingwave-operator.yaml
+++ b/config/risingwave-operator.yaml
@@ -17360,6 +17360,10 @@ spec:
                         - bucket
                         - secret
                         type: object
+                      dataDirectory:
+                        description: DataDirectory is the directory to store the data
+                          in the object storage. It is an optional field.
+                        type: string
                       hdfs:
                         description: HDFS storage spec.
                         properties:

--- a/docs/general/api.md
+++ b/docs/general/api.md
@@ -2459,6 +2459,17 @@ MetaStorageType
 <tbody>
 <tr>
 <td>
+<code>dataDirectory</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>DataDirectory is the directory to store the data in the object storage. It is an optional field.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>memory</code><br/>
 <em>
 bool

--- a/pkg/factory/risingwave_object_factory.go
+++ b/pkg/factory/risingwave_object_factory.go
@@ -441,6 +441,7 @@ func (f *RisingWaveObjectFactory) envsForEtcd() []corev1.EnvVar {
 func (f *RisingWaveObjectFactory) envsForMetaArgs() []corev1.EnvVar {
 	metaPorts := &f.risingwave.Spec.Components.Meta.Ports
 	metaStorage := &f.risingwave.Spec.Storages.Meta
+	objectStorage := f.risingwave.Spec.Storages.Object
 
 	connectorPorts := f.getConnectorPorts()
 	envVars := []corev1.EnvVar{
@@ -459,6 +460,10 @@ func (f *RisingWaveObjectFactory) envsForMetaArgs() []corev1.EnvVar {
 		{
 			Name:  envs.RWStateStore,
 			Value: f.hummockConnectionStr(),
+		},
+		{
+			Name:  envs.RWDataDirectory,
+			Value: objectStorage.DataDirectory,
 		},
 		{
 			Name:  envs.RWDashboardHost,

--- a/pkg/factory/risingwave_object_factory_testcases_test.go
+++ b/pkg/factory/risingwave_object_factory_testcases_test.go
@@ -2487,6 +2487,30 @@ type objectStoragesTestCase struct {
 
 func objectStorageTestCases() map[string]objectStoragesTestCase {
 	return map[string]objectStoragesTestCase{
+		"empty_data_directory": {
+			objectStorage: risingwavev1alpha1.RisingWaveObjectStorage{
+				DataDirectory: "",
+				Memory:        pointer.Bool(true),
+			},
+			envs: []corev1.EnvVar{
+				{
+					Name:  "RW_DATA_DIRECTORY",
+					Value: "",
+				},
+			},
+		},
+		"some_data_directory": {
+			objectStorage: risingwavev1alpha1.RisingWaveObjectStorage{
+				DataDirectory: "1234",
+				Memory:        pointer.Bool(true),
+			},
+			envs: []corev1.EnvVar{
+				{
+					Name:  "RW_DATA_DIRECTORY",
+					Value: "1234",
+				},
+			},
+		},
 		"memory": {
 			objectStorage: risingwavev1alpha1.RisingWaveObjectStorage{
 				Memory: pointer.Bool(true),


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Add a field `.spec.storages.object.dataDirectory` to specify the data directory option on CR

Kind reminder: the legacy way of setting this option will be completely deprecated and will take no effect after this changes merged, cc. @mikechesterwang @wjf3121 

## Checklist

- [x] I have written the necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
