### PR TITLE
build: fix the image url

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,10 +38,10 @@ IMAGE_TAG_BASE ?= risingwavelabs.com/risingwave-operator
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
 BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
 
-REGISTRY ?= ghcr.io/risingwavelabs/risingwave-operator
+REGISTRY ?= ghcr.io/risingwavelabs
 TAG ?= latest
 # Image URL to use all building/pushing image targets
-IMG ?= $(REGISTRY):$(TAG)
+IMG ?= $(REGISTRY)/risingwave-operator:$(TAG)
 
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= crd:crdVersions=v1 

--- a/docs/dev/development.md
+++ b/docs/dev/development.md
@@ -108,7 +108,7 @@ make docker-build
 # Build a image and tag with "risingwave/risingwave-operator:latest"
 REGISTRY=risingwave make docker-build
 
-# Build a image and tag with "risingwave/risingwave-operator:nightly"
+# Build a image and tag with "ghcr.io/risingwavelabs/risingwave-operator:nightly"
 TAG=nightly make docker-build
 ```
 


### PR DESCRIPTION
## What's changed and what's your intention?
Hi, 
This PR is to fix the image url in Makefile when using `make docker-build`. 
I modified the image url based on the development guide.

## Checklist

- [ ] I have written the necessary docs and comments
- [ ] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
