### PR TITLE
docs & ci: fix manifests of local disk deployments

### DIFF
--- a/docs/manifests/risingwave/risingwave-etcd-local-disk.yaml
+++ b/docs/manifests/risingwave/risingwave-etcd-local-disk.yaml
@@ -115,6 +115,15 @@ spec:
       nodeGroups:
       - name: ""
         replicas: 1
+        template:
+          spec:
+            volumes:
+            - name: risingwave-data
+              persistentVolumeClaim:
+                claimName: risingwave-data
+            volumeMounts:
+            - mountPath: /var/lib/risingwave/data
+              name: risingwave-data
     frontend:
       nodeGroups:
       - name: ""

--- a/test/e2e/tests/risingwave/manifests/storages/local-disk.yaml
+++ b/test/e2e/tests/risingwave/manifests/storages/local-disk.yaml
@@ -29,6 +29,15 @@ spec:
       nodeGroups:
       - name: ""
         replicas: 1
+        template:
+          spec:
+            volumes:
+            - name: risingwave-data
+              persistentVolumeClaim:
+                claimName: risingwave-data
+            volumeMounts:
+            - mountPath: /var/lib/risingwave/data
+              name: risingwave-data
     frontend:
       nodeGroups:
       - name: ""


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

> > @hzxa21 Is it true that meta nodes won't query against state store directly. If so, then the example here works perfectly because I excluded the volume mounting of the data directory from the meta's Pod. Otherwise, I need to revise it.
> 
> meta node will not query against state store but it will contact object store backend to store the version checkpoint and backup states so I think making sure meta can read from and write to the object store data directory is neccessary. cc @zwang28

- Mount the data directory on the meta Pod.

## Checklist

- [x] I have written the necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

#439 