### PR TITLE
fix: set a default data directory instead of empty

### DIFF
--- a/apis/risingwave/v1alpha1/risingwave_state_store_backend.go
+++ b/apis/risingwave/v1alpha1/risingwave_state_store_backend.go
@@ -249,7 +249,9 @@ type RisingWaveStateStoreBackendLocalDisk struct {
 // RisingWaveStateStoreBackend is the collection of parameters for the state store that RisingWave uses. Note that one
 // and only one of the first-level fields could be set.
 type RisingWaveStateStoreBackend struct {
-	// DataDirectory is the directory to store the data in the object storage. It is an optional field.
+	// DataDirectory is the directory to store the data in the object storage.
+	// Defaults to hummock.
+	// +kubebuilder:default=hummock
 	DataDirectory string `json:"dataDirectory,omitempty"`
 
 	// Memory indicates to store the data in memory. It's only for test usage and strongly discouraged to

--- a/config/crd/bases/risingwave.risingwavelabs.com_risingwaves.yaml
+++ b/config/crd/bases/risingwave.risingwavelabs.com_risingwaves.yaml
@@ -43813,8 +43813,9 @@ spec:
                     - root
                     type: object
                   dataDirectory:
+                    default: hummock
                     description: DataDirectory is the directory to store the data
-                      in the object storage. It is an optional field.
+                      in the object storage. Defaults to hummock.
                     type: string
                   gcs:
                     description: GCS storage spec.
@@ -44169,8 +44170,9 @@ spec:
                         - root
                         type: object
                       dataDirectory:
+                        default: hummock
                         description: DataDirectory is the directory to store the data
-                          in the object storage. It is an optional field.
+                          in the object storage. Defaults to hummock.
                         type: string
                       gcs:
                         description: GCS storage spec.

--- a/config/risingwave-operator-test.yaml
+++ b/config/risingwave-operator-test.yaml
@@ -50973,8 +50973,9 @@ spec:
                     - root
                     type: object
                   dataDirectory:
+                    default: hummock
                     description: DataDirectory is the directory to store the data
-                      in the object storage. It is an optional field.
+                      in the object storage. Defaults to hummock.
                     type: string
                   gcs:
                     description: GCS storage spec.
@@ -51329,8 +51330,9 @@ spec:
                         - root
                         type: object
                       dataDirectory:
+                        default: hummock
                         description: DataDirectory is the directory to store the data
-                          in the object storage. It is an optional field.
+                          in the object storage. Defaults to hummock.
                         type: string
                       gcs:
                         description: GCS storage spec.

--- a/config/risingwave-operator.yaml
+++ b/config/risingwave-operator.yaml
@@ -50973,8 +50973,9 @@ spec:
                     - root
                     type: object
                   dataDirectory:
+                    default: hummock
                     description: DataDirectory is the directory to store the data
-                      in the object storage. It is an optional field.
+                      in the object storage. Defaults to hummock.
                     type: string
                   gcs:
                     description: GCS storage spec.
@@ -51329,8 +51330,9 @@ spec:
                         - root
                         type: object
                       dataDirectory:
+                        default: hummock
                         description: DataDirectory is the directory to store the data
-                          in the object storage. It is an optional field.
+                          in the object storage. Defaults to hummock.
                         type: string
                       gcs:
                         description: GCS storage spec.

--- a/docs/general/api.md
+++ b/docs/general/api.md
@@ -5328,7 +5328,8 @@ string
 </em>
 </td>
 <td>
-<p>DataDirectory is the directory to store the data in the object storage. It is an optional field.</p>
+<p>DataDirectory is the directory to store the data in the object storage.
+Defaults to hummock.</p>
 </td>
 </tr>
 <tr>
@@ -5926,6 +5927,8 @@ ${BUCKET}.s3.${REGION}.amazonaws.com</p>
 </tr><tr><td><p>&#34;GCS&#34;</p></td>
 <td></td>
 </tr><tr><td><p>&#34;HDFS&#34;</p></td>
+<td></td>
+</tr><tr><td><p>&#34;LocalDisk&#34;</p></td>
 <td></td>
 </tr><tr><td><p>&#34;Memory&#34;</p></td>
 <td></td>

--- a/pkg/webhook/risingwave_conversion.go
+++ b/pkg/webhook/risingwave_conversion.go
@@ -57,7 +57,12 @@ func ConvertGlobalImage(obj *v1alpha1.RisingWave) {
 // ConvertStorages converts v1alpha1 storages.
 // nolint
 func ConvertStorages(obj *v1alpha1.RisingWave) {
-	if !equality.Semantic.DeepEqual(obj.Spec.Storages, v1alpha1.RisingWaveStoragesSpec{}) {
+	if !equality.Semantic.DeepEqual(obj.Spec.Storages, v1alpha1.RisingWaveStoragesSpec{}) &&
+		!equality.Semantic.DeepEqual(obj.Spec.Storages, v1alpha1.RisingWaveStoragesSpec{
+			Object: v1alpha1.RisingWaveStateStoreBackend{
+				DataDirectory: "hummock",
+			},
+		}) {
 		obj.Spec.MetaStore = *obj.Spec.Storages.Meta.DeepCopy()
 		obj.Spec.StateStore = *obj.Spec.Storages.Object.DeepCopy()
 	}


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Set the default data directory to `hummock` if it's not provided. It will mitigate the problems mentioned in #441 
- Note that this change will affect any existing RisingWave objects if they have an empty data directory. 

## Checklist

- [x] I have written the necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

fix #441 