### PR TITLE
fix: fix validation on s3 credentials

### DIFF
--- a/pkg/webhook/risingwave_validating_webhook.go
+++ b/pkg/webhook/risingwave_validating_webhook.go
@@ -178,7 +178,7 @@ func (v *RisingWaveValidatingWebhook) validateMetaStoreAndStateStore(path *field
 			}
 		} else {
 			// AWS S3.
-			if !pointer.BoolDeref(stateStore.S3.UseServiceAccount, false) == (stateStore.S3.RisingWaveS3Credentials.SecretName == "") {
+			if !pointer.BoolDeref(stateStore.S3.UseServiceAccount, false) && stateStore.S3.RisingWaveS3Credentials.SecretName == "" {
 				fieldErrs = append(fieldErrs, field.Invalid(path.Child("stateStore", "s3", "credentials"), stateStore.S3.SecretName, "either secretName or useServiceAccount must be specified"))
 			}
 		}

--- a/pkg/webhook/risingwave_validating_webhook_test.go
+++ b/pkg/webhook/risingwave_validating_webhook_test.go
@@ -355,6 +355,20 @@ func Test_RisingWaveValidatingWebhook_ValidateCreate(t *testing.T) {
 			},
 			pass: true,
 		},
+		"s3-state-store-use-service-account-pass-1": {
+			patch: func(r *risingwavev1alpha1.RisingWave) {
+				r.Spec.StateStore = risingwavev1alpha1.RisingWaveStateStoreBackend{
+					S3: &risingwavev1alpha1.RisingWaveStateStoreBackendS3{
+						Bucket: "hummock",
+						RisingWaveS3Credentials: risingwavev1alpha1.RisingWaveS3Credentials{
+							UseServiceAccount: pointer.Bool(true),
+							SecretName:        "s3-creds",
+						},
+					},
+				}
+			},
+			pass: true,
+		},
 		"s3-state-store-no-credentials-fail": {
 			patch: func(r *risingwavev1alpha1.RisingWave) {
 				r.Spec.StateStore = risingwavev1alpha1.RisingWaveStateStoreBackend{


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Fix the validation issue when `useServiceAccount` is true but the `secretName` is also provided.

## Checklist

- [x] I have written the necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
