### PR TITLE
remind users to adjust data directory just in case

### DIFF
--- a/docs/manifests/risingwave/risingwave-etcd-s3.yaml
+++ b/docs/manifests/risingwave/risingwave-etcd-s3.yaml
@@ -77,6 +77,7 @@ spec:
     etcd:
       endpoint: risingwave-etcd:2388
   stateStore:
+    dataDirectory: hummock001-directory
     s3:
       bucket: hummock001
       credentials:


### PR DESCRIPTION
## What's changed and what's your intention?

As risingwave does not allow an empty data directory or a data directory that has already been used to avoid confusion, some users ask how they can change it when they deploy RW via k8s.

***PLEASE DO NOT LEAVE THIS EMPTY !!!***
