### PR TITLE
feat & fix: add an annotation to allow bypassing the validating webho…

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -36,9 +36,10 @@ const (
 
 // System reserved annotations.
 const (
-	AnnotationRestartAt          = "risingwave/restart-at"
-	AnnotationPauseReconcile     = "risingwave.risingwavelabs.com/pause-reconcile"
-	AnnotationInheritLabelPrefix = "risingwave.risingwavelabs.com/inherit-label-prefix"
+	AnnotationRestartAt               = "risingwave/restart-at"
+	AnnotationPauseReconcile          = "risingwave.risingwavelabs.com/pause-reconcile"
+	AnnotationBypassValidatingWebhook = "risingwave.risingwavelabs.com/bypass-validating-webhook"
+	AnnotationInheritLabelPrefix      = "risingwave.risingwavelabs.com/inherit-label-prefix"
 )
 
 // =================================================


### PR DESCRIPTION
…ok for emergency updates, fix the validation on meta & state stores

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Allow bypass the validating webhook with annotation `risingwave.risingwavelabs.com/bypass-validating-webhook: "true"`. It's useful when a RisingWave resource is broken but updates will be blocked by the webhook.
- Fix the validating webhook on meta & state stores.

## Checklist

- [ ] I have written the necessary docs and comments
- [ ] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
