### PR TITLE
refactor: reflect recreate upgrade type on sts

### DIFF
--- a/pkg/factory/risingwave_object_factory.go
+++ b/pkg/factory/risingwave_object_factory.go
@@ -1630,6 +1630,13 @@ func buildUpgradeStrategyForStatefulSet(strategy risingwavev1alpha1.RisingWaveNo
 				MaxUnavailable: rollingUpdateOrDefault(strategy.RollingUpdate).MaxUnavailable,
 			},
 		}
+	case risingwavev1alpha1.RisingWaveUpgradeStrategyTypeRecreate:
+		return appsv1.StatefulSetUpdateStrategy{
+			Type: appsv1.RollingUpdateStatefulSetStrategyType,
+			RollingUpdate: &appsv1.RollingUpdateStatefulSetStrategy{
+				MaxUnavailable: &intstr.IntOrString{Type: intstr.String, StrVal: "100%"},
+			},
+		}
 	default:
 		return appsv1.StatefulSetUpdateStrategy{}
 	}

--- a/pkg/factory/risingwave_object_factory_testcases_test.go
+++ b/pkg/factory/risingwave_object_factory_testcases_test.go
@@ -629,7 +629,12 @@ func metaStatefulSetTestCases() map[string]metaStatefulSetTestCase {
 					},
 				},
 			},
-			expectedUpgradeStrategy: &appsv1.StatefulSetUpdateStrategy{},
+			expectedUpgradeStrategy: &appsv1.StatefulSetUpdateStrategy{
+				Type: appsv1.RollingUpdateStatefulSetStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateStatefulSetStrategy{
+					MaxUnavailable: &intstr.IntOrString{Type: intstr.String, StrVal: "100%"},
+				},
+			},
 		},
 		"upgrade-strategy-rolling-update-max-unavailable-50%": {
 			group: risingwavev1alpha1.RisingWaveNodeGroup{
@@ -925,7 +930,12 @@ func computeStatefulSetTestCases() map[string]computeStatefulSetTestCase {
 					},
 				},
 			},
-			expectedUpgradeStrategy: &appsv1.StatefulSetUpdateStrategy{},
+			expectedUpgradeStrategy: &appsv1.StatefulSetUpdateStrategy{
+				Type: appsv1.RollingUpdateStatefulSetStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateStatefulSetStrategy{
+					MaxUnavailable: &intstr.IntOrString{Type: intstr.String, StrVal: "100%"},
+				},
+			},
 		},
 		"upgrade-strategy-rolling-update-max-unavailable-50%": {
 			group: risingwavev1alpha1.RisingWaveNodeGroup{


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Before this change, the Recreate upgrade type has no effect. But it does mean we don't care about how many Pods will be alive during the upgrading so it's more appropriate to set it to `rollingUpgrade` with `maxUnavaialbe` equals to `100%`.

## Checklist

- [x] I have written the necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
