### PR TITLE
doc: Grafana accept requests from external hosts

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -34,4 +34,10 @@ kubectl port-forward -n monitoring svc/prometheus-grafana 3000:http-web
 Now we can access the Grafana inside the Kubernetes via [http://localhost:3000](http://localhost:3000). By default, the username is `admin` and the password is `prom-operator`.
 Let's open the `RisingWave/RisingWave Dashboard` and select the instance you'd like to observe, and here are the panels.
 
+The command above only allows access from the local machine.
+If we want to let Grafana accept requests from external hosts, e.g. another machine:
+```shell
+kubectl port-forward -n monitoring svc/prometheus-grafana 3000:http-web --address 0.0.0.0
+```
+
 ![RisingWave Dashboard](../docs/assets/risingwave-dashboard.png)

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -34,7 +34,7 @@ kubectl port-forward -n monitoring svc/prometheus-grafana 3000:http-web
 Now we can access the Grafana inside the Kubernetes via [http://localhost:3000](http://localhost:3000). By default, the username is `admin` and the password is `prom-operator`.
 Let's open the `RisingWave/RisingWave Dashboard` and select the instance you'd like to observe, and here are the panels.
 
-The command above only allows access from the local machine.
+The command above allows access from the local machine only.
 If we want to let Grafana accept requests from external hosts, e.g. another machine:
 ```shell
 kubectl port-forward -n monitoring svc/prometheus-grafana 3000:http-web --address 0.0.0.0


### PR DESCRIPTION
## What's changed and what's your intention?

Add instructions for Grafana to accept requests from external hosts via `kubectl port-forward`

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [ ] I have written the necessary docs and comments
- [ ] ~I have added necessary unit tests and integration tests~

## Refer to a related PR or issue link (optional)
