### PR TITLE
start connector node by default

### DIFF
--- a/docs/manifests/stable/persistent/minio/risingwave.yaml
+++ b/docs/manifests/stable/persistent/minio/risingwave.yaml
@@ -205,3 +205,8 @@ spec:
       nodeGroups:
       - replicas: 1
         name: ''
+    # Please comment out the following if you do not need connector node
+    connector:
+      nodeGroups:
+      - replicas: 1
+        name: ''

--- a/docs/manifests/stable/persistent/s3/risingwave.yaml
+++ b/docs/manifests/stable/persistent/s3/risingwave.yaml
@@ -122,3 +122,8 @@ spec:
       nodeGroups:
       - replicas: 1
         name: ''
+    # Please comment out the following if you do not need connector node
+    connector:
+      nodeGroups:
+      - replicas: 1
+        name: ''


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

These two yaml files are the default ones that get used by users, e.g. reading README.md in this Repo or reading documentation at risingwave.dev.

I think we can start the connector node by default as it is a must for `postgres-cdc` and other advanced sources/sinks.

They typically encounter `transport error` when they try to establish source without starting a connector node.

Try to reduce the friction and confusion.

## Checklist

- [x] I have written the necessary docs and comments
- [ ] ~I have added necessary unit tests and integration tests~

## Refer to a related PR or issue link (optional)
