### PR TITLE
feat: set startup probe to prevent from unnecessary restarts

### DIFF
--- a/pkg/factory/risingwave_object_factory.go
+++ b/pkg/factory/risingwave_object_factory.go
@@ -984,7 +984,17 @@ func basicSetupRisingWaveContainer(container *corev1.Container, component *risin
 	}
 
 	// Set the default probes.
-	container.StartupProbe = nil
+	container.StartupProbe = &corev1.Probe{
+		InitialDelaySeconds: 5,
+		PeriodSeconds:       5,
+		TimeoutSeconds:      5,
+		FailureThreshold:    12,
+		ProbeHandler: corev1.ProbeHandler{
+			TCPSocket: &corev1.TCPSocketAction{
+				Port: intstr.FromString(consts.PortService),
+			},
+		},
+	}
 	container.LivenessProbe = &corev1.Probe{
 		InitialDelaySeconds: 2,
 		PeriodSeconds:       10,


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- As title. Using startup probe can prevent pods from restarting when meta isn't fully initialized. It helps bootstrapping a RisingWave cluster more smoothly.
- Note that this is a change that will affect existing clusters: after any kind of manifest operations, all RisingWave pods will get recreated.

## Checklist

- [ ] I have written the necessary docs and comments
- [ ] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
