### PR TITLE
eliminate the need to clone the repo in order to install monitoring

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -5,7 +5,7 @@
 You can install the monitoring stack manually or via the install script.
 
 ```shell
-./monitoring/install.sh
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/risingwavelabs/risingwave-operator/main/monitoring/install.sh)"
 ```
 
 It will create the `monitoring` namespace and deploy everything inside it.

--- a/monitoring/install.sh
+++ b/monitoring/install.sh
@@ -64,5 +64,5 @@ echo $msg
 
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm --namespace $ns upgrade --install --create-namespace prometheus prometheus-community/kube-prometheus-stack \
-	-f "${_SCRIPT_BASEDIR}"/kube-prometheus-stack.yaml \
+	-f https://raw.githubusercontent.com/risingwavelabs/risingwave-operator/main/monitoring/kube-prometheus-stack.yaml \
 	$dryParam


### PR DESCRIPTION
## What's changed and what's your intention?

The idea is that users can directly call the command for installation. I've tested the script, and it ran successfully. However I was not able to export the port 3000 because it kept pending.

```
kubectl port-forward -n monitoring svc/prometheus-grafana 3000:http-web
error: unable to forward port because pod is not running. Current status=Pending
```

## Checklist

- [x] I have written the necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
