### PR TITLE
chore: remove RW_METRICS_LEVEL env

### DIFF
--- a/pkg/factory/envs/risingwave.go
+++ b/pkg/factory/envs/risingwave.go
@@ -38,7 +38,6 @@ const (
 	RWBackend                     = "RW_BACKEND"
 	RWMetaAddr                    = "RW_META_ADDR"
 	RWMetaAddrLegacy              = "RW_META_ADDRESS" // Will deprecate soon.
-	RWMetricsLevel                = "RW_METRICS_LEVEL"
 	RWPrometheusListenerAddr      = "RW_PROMETHEUS_LISTENER_ADDR"
 	RWParallelism                 = "RW_PARALLELISM"
 	RWTotalMemoryBytes            = "RW_TOTAL_MEMORY_BYTES"

--- a/pkg/factory/risingwave_object_factory.go
+++ b/pkg/factory/risingwave_object_factory.go
@@ -360,6 +360,10 @@ func (f *RisingWaveObjectFactory) envsForMetaArgs() []corev1.EnvVar {
 			Name:  envs.RWConnectorRPCEndPoint,
 			Value: fmt.Sprintf("%s:%d", f.componentAddr(consts.ComponentConnector, ""), consts.ConnectorServicePort),
 		},
+		{
+			Name:  envs.RWMetricsLevel,
+			Value: "info",
+		},
 	}
 
 	switch {

--- a/pkg/factory/risingwave_object_factory.go
+++ b/pkg/factory/risingwave_object_factory.go
@@ -360,10 +360,6 @@ func (f *RisingWaveObjectFactory) envsForMetaArgs() []corev1.EnvVar {
 			Name:  envs.RWConnectorRPCEndPoint,
 			Value: fmt.Sprintf("%s:%d", f.componentAddr(consts.ComponentConnector, ""), consts.ConnectorServicePort),
 		},
-		{
-			Name:  envs.RWMetricsLevel,
-			Value: "info",
-		},
 	}
 
 	switch {
@@ -420,10 +416,6 @@ func (f *RisingWaveObjectFactory) envsForFrontendArgs() []corev1.EnvVar {
 			Value: fmt.Sprintf("load-balance+http://%s:%d", f.componentAddr(consts.ComponentMeta, ""), consts.MetaServicePort),
 		},
 		{
-			Name:  envs.RWMetricsLevel,
-			Value: "info",
-		},
-		{
 			Name:  envs.RWPrometheusListenerAddr,
 			Value: fmt.Sprintf("0.0.0.0:%d", consts.FrontendMetricsPort),
 		},
@@ -451,10 +443,6 @@ func (f *RisingWaveObjectFactory) envsForComputeArgs(cpuLimit int64, memLimit in
 		{
 			Name:  envs.RWMetaAddrLegacy,
 			Value: fmt.Sprintf("load-balance+http://%s:%d", f.componentAddr(consts.ComponentMeta, ""), consts.MetaServicePort),
-		},
-		{
-			Name:  envs.RWMetricsLevel,
-			Value: "info",
 		},
 		{
 			Name:  envs.RWConnectorRPCEndPoint,
@@ -508,10 +496,6 @@ func (f *RisingWaveObjectFactory) envsForCompactorArgs() []corev1.EnvVar {
 		{
 			Name:  envs.RWMetaAddrLegacy,
 			Value: fmt.Sprintf("load-balance+http://%s:%d", f.componentAddr(consts.ComponentMeta, ""), consts.MetaServicePort),
-		},
-		{
-			Name:  envs.RWMetricsLevel,
-			Value: "info",
 		},
 	}
 }

--- a/pkg/factory/risingwave_object_factory.go
+++ b/pkg/factory/risingwave_object_factory.go
@@ -417,7 +417,7 @@ func (f *RisingWaveObjectFactory) envsForFrontendArgs() []corev1.EnvVar {
 		},
 		{
 			Name:  envs.RWMetricsLevel,
-			Value: "1",
+			Value: "info",
 		},
 		{
 			Name:  envs.RWPrometheusListenerAddr,
@@ -450,7 +450,7 @@ func (f *RisingWaveObjectFactory) envsForComputeArgs(cpuLimit int64, memLimit in
 		},
 		{
 			Name:  envs.RWMetricsLevel,
-			Value: "1",
+			Value: "info",
 		},
 		{
 			Name:  envs.RWConnectorRPCEndPoint,
@@ -507,7 +507,7 @@ func (f *RisingWaveObjectFactory) envsForCompactorArgs() []corev1.EnvVar {
 		},
 		{
 			Name:  envs.RWMetricsLevel,
-			Value: "1",
+			Value: "info",
 		},
 	}
 }


### PR DESCRIPTION
## What's changed and what's your intention?

https://github.com/risingwavelabs/risingwave/pull/12099

The above PR changes the default value of this environment variable to 'info', 1 is an invalid value.

## Checklist

- [x] I have written the necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
