### PR TITLE
feat: set RW_META_ADDR in meta pod, used by risectl

### DIFF
--- a/pkg/factory/risingwave_object_factory.go
+++ b/pkg/factory/risingwave_object_factory.go
@@ -353,6 +353,10 @@ func (f *RisingWaveObjectFactory) envsForMetaArgs() []corev1.EnvVar {
 			Value: fmt.Sprintf("0.0.0.0:%d", consts.MetaDashboardPort),
 		},
 		{
+			Name:  envs.RWMetaAddr,
+			Value: fmt.Sprintf("http://127.0.0.1:%d", consts.MetaServicePort),
+		},
+		{
 			Name:  envs.RWPrometheusHost,
 			Value: fmt.Sprintf("0.0.0.0:%d", consts.MetaMetricsPort),
 		},


### PR DESCRIPTION
## What's changed and what's your intention?

As title. `risectl` will use `RW_META_ADDR` to connect to Meta Node. For Meta node itself, the address is localhost

## Checklist

- [ ] I have written the necessary docs and comments
- [ ] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
