### PR TITLE
chore: fix resource limit

### DIFF
--- a/docs/manifests/risingwave/risingwave-aliyun-oss.yaml
+++ b/docs/manifests/risingwave/risingwave-aliyun-oss.yaml
@@ -27,15 +27,51 @@ spec:
       nodeGroups:
       - replicas: 1
         name: ""
+        template:
+          spec:
+            resources:
+              limits:
+                cpu: 1
+                memory: 2Gi
+              requests:
+                cpu: 1
+                memory: 2Gi
     frontend:
       nodeGroups:
       - replicas: 1
         name: ""
+        template:
+          spec:
+            resources:
+              limits:
+                cpu: 1
+                memory: 2Gi
+              requests:
+                cpu: 1
+                memory: 2Gi
     compute:
       nodeGroups:
       - replicas: 1
         name: ""
+        template:
+          spec:
+            resources:
+              limits:
+                cpu: 8
+                memory: 32Gi # Memory limit will be set to `RW_TOTAL_MEMORY_BYTES`
+              requests:
+                cpu: 8
+                memory: 32Gi
     compactor:
       nodeGroups:
       - replicas: 1
         name: ""
+        template:
+          spec:
+            resources:
+              limits:
+                cpu: 4
+                memory: 8Gi
+              requests:
+                cpu: 4
+                memory: 8Gi

--- a/docs/manifests/risingwave/risingwave-azure.yaml
+++ b/docs/manifests/risingwave/risingwave-azure.yaml
@@ -26,15 +26,51 @@ spec:
       nodeGroups:
       - replicas: 1
         name: ""
+        template:
+          spec:
+            resources:
+              limits:
+                cpu: 1
+                memory: 2Gi
+              requests:
+                cpu: 1
+                memory: 2Gi
     frontend:
       nodeGroups:
       - replicas: 1
         name: ""
+        template:
+          spec:
+            resources:
+              limits:
+                cpu: 1
+                memory: 2Gi
+              requests:
+                cpu: 1
+                memory: 2Gi
     compute:
       nodeGroups:
       - replicas: 1
         name: ""
+        template:
+          spec:
+            resources:
+              limits:
+                cpu: 8
+                memory: 32Gi # Memory limit will be set to `RW_TOTAL_MEMORY_BYTES`
+              requests:
+                cpu: 8
+                memory: 32Gi
     compactor:
       nodeGroups:
       - replicas: 1
         name: ""
+        template:
+          spec:
+            resources:
+              limits:
+                cpu: 4
+                memory: 8Gi
+              requests:
+                cpu: 4
+                memory: 8Gi

--- a/docs/manifests/risingwave/risingwave-customize-config.yaml
+++ b/docs/manifests/risingwave/risingwave-customize-config.yaml
@@ -48,10 +48,10 @@ spec:
             resources:
               limits:
                 cpu: 1
-                memory: 1Gi
+                memory: 2Gi
               requests:
-                cpu: 100m
-                memory: 100Mi
+                cpu: 1
+                memory: 2Gi
     frontend:
       nodeGroups:
       - replicas: 1
@@ -61,10 +61,10 @@ spec:
             resources:
               limits:
                 cpu: 1
-                memory: 1Gi
+                memory: 2Gi
               requests:
-                cpu: 100m
-                memory: 100Mi
+                cpu: 1
+                memory: 2Gi
     compute:
       nodeGroups:
       - replicas: 1
@@ -73,11 +73,11 @@ spec:
           spec:
             resources:
               limits:
-                cpu: 1
-                memory: 1Gi
+                cpu: 8
+                memory: 32Gi # Memory limit will be set to `RW_TOTAL_MEMORY_BYTES`
               requests:
-                cpu: 100m
-                memory: 100Mi
+                cpu: 8
+                memory: 32Gi
     compactor:
       nodeGroups:
       - replicas: 1
@@ -86,8 +86,8 @@ spec:
           spec:
             resources:
               limits:
-                cpu: 1
-                memory: 1Gi
+                cpu: 4
+                memory: 8Gi
               requests:
-                cpu: 100m
-                memory: 100Mi
+                cpu: 4
+                memory: 8Gi

--- a/docs/manifests/risingwave/risingwave-etcd-auth.yaml
+++ b/docs/manifests/risingwave/risingwave-etcd-auth.yaml
@@ -108,10 +108,10 @@ spec:
             resources:
               limits:
                 cpu: 1
-                memory: 1Gi
+                memory: 2Gi
               requests:
-                cpu: 100m
-                memory: 100Mi
+                cpu: 1
+                memory: 2Gi
     frontend:
       nodeGroups:
       - replicas: 1
@@ -121,10 +121,10 @@ spec:
             resources:
               limits:
                 cpu: 1
-                memory: 1Gi
+                memory: 2Gi
               requests:
-                cpu: 100m
-                memory: 100Mi
+                cpu: 1
+                memory: 2Gi
     compute:
       nodeGroups:
       - replicas: 1
@@ -133,11 +133,11 @@ spec:
           spec:
             resources:
               limits:
-                cpu: 1
-                memory: 1Gi
+                cpu: 8
+                memory: 32Gi # Memory limit will be set to `RW_TOTAL_MEMORY_BYTES`
               requests:
-                cpu: 100m
-                memory: 100Mi
+                cpu: 8
+                memory: 32Gi
     compactor:
       nodeGroups:
       - replicas: 1
@@ -146,8 +146,8 @@ spec:
           spec:
             resources:
               limits:
-                cpu: 1
-                memory: 1Gi
+                cpu: 4
+                memory: 8Gi
               requests:
-                cpu: 100m
-                memory: 100Mi
+                cpu: 4
+                memory: 8Gi

--- a/docs/manifests/risingwave/risingwave-etcd-hdfs.yaml
+++ b/docs/manifests/risingwave/risingwave-etcd-hdfs.yaml
@@ -407,10 +407,10 @@ spec:
               resources:
                 limits:
                   cpu: 1
-                  memory: 1Gi
+                  memory: 2Gi
                 requests:
-                  cpu: 100m
-                  memory: 100Mi
+                  cpu: 1
+                  memory: 2Gi
     frontend:
       nodeGroups:
         - replicas: 1
@@ -420,10 +420,10 @@ spec:
               resources:
                 limits:
                   cpu: 1
-                  memory: 1Gi
+                  memory: 2Gi
                 requests:
-                  cpu: 100m
-                  memory: 100Mi
+                  cpu: 1
+                  memory: 2Gi
     compute:
       nodeGroups:
         - replicas: 1
@@ -432,11 +432,11 @@ spec:
             spec:
               resources:
                 limits:
-                  cpu: 1
-                  memory: 1Gi
+                  cpu: 8
+                  memory: 32Gi # Memory limit will be set to `RW_TOTAL_MEMORY_BYTES`
                 requests:
-                  cpu: 100m
-                  memory: 100Mi
+                  cpu: 8
+                  memory: 32Gi
     compactor:
       nodeGroups:
         - replicas: 1
@@ -445,8 +445,8 @@ spec:
             spec:
               resources:
                 limits:
-                  cpu: 1
-                  memory: 1Gi
+                  cpu: 4
+                  memory: 8Gi
                 requests:
-                  cpu: 100m
-                  memory: 100Mi
+                  cpu: 4
+                  memory: 8Gi

--- a/docs/manifests/risingwave/risingwave-etcd-local-disk.yaml
+++ b/docs/manifests/risingwave/risingwave-etcd-local-disk.yaml
@@ -126,6 +126,13 @@ spec:
             volumeMounts:
             - mountPath: /var/lib/risingwave/data
               name: risingwave-data
+            resources:
+              limits:
+                cpu: 1
+                memory: 2Gi
+              requests:
+                cpu: 1
+                memory: 2Gi
     frontend:
       nodeGroups:
       - name: ""
@@ -139,6 +146,13 @@ spec:
                   labelSelector:
                     matchLabels:
                       risingwave/component: meta
+            resources:
+              limits:
+                cpu: 1
+                memory: 2Gi
+              requests:
+                cpu: 1
+                memory: 2Gi
     compute:
       nodeGroups:
       - name: ""
@@ -159,6 +173,13 @@ spec:
                   labelSelector:
                     matchLabels:
                       risingwave/component: meta
+            resources:
+              limits:
+                cpu: 8
+                memory: 32Gi # Memory limit will be set to `RW_TOTAL_MEMORY_BYTES`
+              requests:
+                cpu: 8
+                memory: 32Gi
     compactor:
       nodeGroups:
       - name: ""
@@ -179,3 +200,10 @@ spec:
                   labelSelector:
                     matchLabels:
                       risingwave/component: meta
+            resources:
+              limits:
+                cpu: 4
+                memory: 8Gi
+              requests:
+                cpu: 4
+                memory: 8Gi

--- a/docs/manifests/risingwave/risingwave-etcd-minio.yaml
+++ b/docs/manifests/risingwave/risingwave-etcd-minio.yaml
@@ -165,10 +165,10 @@ spec:
             resources:
               limits:
                 cpu: 1
-                memory: 1Gi
+                memory: 2Gi
               requests:
-                cpu: 100m
-                memory: 100Mi
+                cpu: 1
+                memory: 2Gi
     frontend:
       nodeGroups:
       - replicas: 1
@@ -178,10 +178,10 @@ spec:
             resources:
               limits:
                 cpu: 1
-                memory: 1Gi
+                memory: 2Gi
               requests:
-                cpu: 100m
-                memory: 100Mi
+                cpu: 1
+                memory: 2Gi
     compute:
       nodeGroups:
       - replicas: 1
@@ -190,11 +190,11 @@ spec:
           spec:
             resources:
               limits:
-                cpu: 1
-                memory: 1Gi
+                cpu: 8
+                memory: 32Gi # Memory limit will be set to `RW_TOTAL_MEMORY_BYTES`
               requests:
-                cpu: 100m
-                memory: 100Mi
+                cpu: 8
+                memory: 32Gi
     compactor:
       nodeGroups:
       - replicas: 1
@@ -203,8 +203,8 @@ spec:
           spec:
             resources:
               limits:
-                cpu: 1
-                memory: 1Gi
+                cpu: 4
+                memory: 8Gi
               requests:
-                cpu: 100m
-                memory: 100Mi
+                cpu: 4
+                memory: 8Gi

--- a/docs/manifests/risingwave/risingwave-etcd-s3.yaml
+++ b/docs/manifests/risingwave/risingwave-etcd-s3.yaml
@@ -124,10 +124,10 @@ spec:
             resources:
               limits:
                 cpu: 8
-                memory: 32Gi
+                memory: 32Gi # Memory limit will be set to `RW_TOTAL_MEMORY_BYTES`
               requests:
                 cpu: 8
-                memory: 30Gi
+                memory: 32Gi
     compactor:
       nodeGroups:
       - replicas: 1

--- a/docs/manifests/risingwave/risingwave-etcd-s3.yaml
+++ b/docs/manifests/risingwave/risingwave-etcd-s3.yaml
@@ -98,10 +98,10 @@ spec:
             resources:
               limits:
                 cpu: 1
-                memory: 1Gi
+                memory: 2Gi
               requests:
-                cpu: 100m
-                memory: 100Mi
+                cpu: 1
+                memory: 2Gi
     frontend:
       nodeGroups:
       - replicas: 1
@@ -111,10 +111,10 @@ spec:
             resources:
               limits:
                 cpu: 1
-                memory: 1Gi
+                memory: 2Gi
               requests:
-                cpu: 100m
-                memory: 100Mi
+                cpu: 1
+                memory: 2Gi
     compute:
       nodeGroups:
       - replicas: 1
@@ -123,11 +123,11 @@ spec:
           spec:
             resources:
               limits:
-                cpu: 1
-                memory: 1Gi
+                cpu: 8
+                memory: 32Gi
               requests:
-                cpu: 100m
-                memory: 100Mi
+                cpu: 8
+                memory: 30Gi
     compactor:
       nodeGroups:
       - replicas: 1
@@ -136,8 +136,8 @@ spec:
           spec:
             resources:
               limits:
-                cpu: 1
-                memory: 1Gi
+                cpu: 4
+                memory: 8Gi
               requests:
-                cpu: 100m
-                memory: 100Mi
+                cpu: 4
+                memory: 8Gi

--- a/docs/manifests/risingwave/risingwave-gcs.yaml
+++ b/docs/manifests/risingwave/risingwave-gcs.yaml
@@ -30,10 +30,10 @@ spec:
             resources:
               limits:
                 cpu: 1
-                memory: 1Gi
+                memory: 2Gi
               requests:
-                cpu: 100m
-                memory: 100Mi
+                cpu: 1
+                memory: 2Gi
     frontend:
       nodeGroups:
       - replicas: 1
@@ -43,10 +43,10 @@ spec:
             resources:
               limits:
                 cpu: 1
-                memory: 1Gi
+                memory: 2Gi
               requests:
-                cpu: 100m
-                memory: 100Mi
+                cpu: 1
+                memory: 2Gi
     compute:
       nodeGroups:
       - replicas: 1
@@ -55,11 +55,11 @@ spec:
           spec:
             resources:
               limits:
-                cpu: 1
-                memory: 1Gi
+                cpu: 8
+                memory: 32Gi # Memory limit will be set to `RW_TOTAL_MEMORY_BYTES`
               requests:
-                cpu: 100m
-                memory: 100Mi
+                cpu: 8
+                memory: 32Gi
     compactor:
       nodeGroups:
       - replicas: 1
@@ -68,8 +68,8 @@ spec:
           spec:
             resources:
               limits:
-                cpu: 1
-                memory: 1Gi
+                cpu: 4
+                memory: 8Gi
               requests:
-                cpu: 100m
-                memory: 100Mi
+                cpu: 4
+                memory: 8Gi

--- a/docs/manifests/risingwave/risingwave-hdfs.yaml
+++ b/docs/manifests/risingwave/risingwave-hdfs.yaml
@@ -334,10 +334,10 @@ spec:
               resources:
                 limits:
                   cpu: 1
-                  memory: 1Gi
+                  memory: 2Gi
                 requests:
-                  cpu: 100m
-                  memory: 100Mi
+                  cpu: 1
+                  memory: 2Gi
     frontend:
       nodeGroups:
         - replicas: 1
@@ -347,10 +347,10 @@ spec:
               resources:
                 limits:
                   cpu: 1
-                  memory: 1Gi
+                  memory: 2Gi
                 requests:
-                  cpu: 100m
-                  memory: 100Mi
+                  cpu: 1
+                  memory: 2Gi
     compute:
       nodeGroups:
         - replicas: 1
@@ -359,11 +359,11 @@ spec:
             spec:
               resources:
                 limits:
-                  cpu: 1
-                  memory: 1Gi
+                  cpu: 8
+                  memory: 32Gi # Memory limit will be set to `RW_TOTAL_MEMORY_BYTES`
                 requests:
-                  cpu: 100m
-                  memory: 100Mi
+                  cpu: 8
+                  memory: 32Gi
     compactor:
       nodeGroups:
         - replicas: 1
@@ -372,8 +372,8 @@ spec:
             spec:
               resources:
                 limits:
-                  cpu: 1
-                  memory: 1Gi
+                  cpu: 4
+                  memory: 8Gi
                 requests:
-                  cpu: 100m
-                  memory: 100Mi
+                  cpu: 4
+                  memory: 8Gi

--- a/docs/manifests/risingwave/risingwave-in-memory.yaml
+++ b/docs/manifests/risingwave/risingwave-in-memory.yaml
@@ -13,15 +13,51 @@ spec:
       nodeGroups:
       - replicas: 1
         name: ""
+        template:
+          spec:
+            resources:
+              limits:
+                cpu: 1
+                memory: 2Gi
+              requests:
+                cpu: 1
+                memory: 2Gi
     frontend:
       nodeGroups:
       - replicas: 1
         name: ""
+        template:
+          spec:
+            resources:
+              limits:
+                cpu: 1
+                memory: 2Gi
+              requests:
+                cpu: 1
+                memory: 2Gi
     compute:
       nodeGroups:
       - replicas: 1
         name: ""
+        template:
+          spec:
+            resources:
+              limits:
+                cpu: 8
+                memory: 32Gi # Memory limit will be set to `RW_TOTAL_MEMORY_BYTES`
+              requests:
+                cpu: 8
+                memory: 32Gi
     compactor:
       nodeGroups:
       - replicas: 1
         name: ""
+        template:
+          spec:
+            resources:
+              limits:
+                cpu: 4
+                memory: 8Gi
+              requests:
+                cpu: 4
+                memory: 8Gi

--- a/docs/manifests/risingwave/risingwave-s3-compatible.yaml
+++ b/docs/manifests/risingwave/risingwave-s3-compatible.yaml
@@ -31,10 +31,10 @@ spec:
             resources:
               limits:
                 cpu: 1
-                memory: 1Gi
+                memory: 2Gi
               requests:
-                cpu: 100m
-                memory: 100Mi
+                cpu: 1
+                memory: 2Gi
     frontend:
       nodeGroups:
       - replicas: 1
@@ -44,10 +44,10 @@ spec:
             resources:
               limits:
                 cpu: 1
-                memory: 1Gi
+                memory: 2Gi
               requests:
-                cpu: 100m
-                memory: 100Mi
+                cpu: 1
+                memory: 2Gi
     compute:
       nodeGroups:
       - replicas: 1
@@ -56,11 +56,11 @@ spec:
           spec:
             resources:
               limits:
-                cpu: 1
-                memory: 1Gi
+                cpu: 8
+                memory: 32Gi # Memory limit will be set to `RW_TOTAL_MEMORY_BYTES`
               requests:
-                cpu: 100m
-                memory: 100Mi
+                cpu: 8
+                memory: 32Gi
     compactor:
       nodeGroups:
       - replicas: 1
@@ -69,8 +69,8 @@ spec:
           spec:
             resources:
               limits:
-                cpu: 1
-                memory: 1Gi
+                cpu: 4
+                memory: 8Gi
               requests:
-                cpu: 100m
-                memory: 100Mi
+                cpu: 4
+                memory: 8Gi

--- a/docs/manifests/stable/memory/risingwave.yaml
+++ b/docs/manifests/stable/memory/risingwave.yaml
@@ -13,15 +13,51 @@ spec:
       nodeGroups:
       - replicas: 1
         name: ''
+        template:
+          spec:
+            resources:
+              limits:
+                cpu: 1
+                memory: 2Gi
+              requests:
+                cpu: 1
+                memory: 2Gi
     compactor:
       nodeGroups:
       - replicas: 1
         name: ''
+        template:
+          spec:
+            resources:
+              limits:
+                cpu: 4
+                memory: 8Gi
+              requests:
+                cpu: 4
+                memory: 8Gi
     frontend:
       nodeGroups:
       - replicas: 1
         name: ''
+        template:
+          spec:
+            resources:
+              limits:
+                cpu: 1
+                memory: 2Gi
+              requests:
+                cpu: 1
+                memory: 2Gi
     compute:
       nodeGroups:
       - replicas: 1
         name: ''
+        template:
+          spec:
+            resources:
+              limits:
+                cpu: 8
+                memory: 32Gi # Memory limit will be set to `RW_TOTAL_MEMORY_BYTES`
+              requests:
+                cpu: 8
+                memory: 32Gi

--- a/docs/manifests/stable/persistent/minio/risingwave.yaml
+++ b/docs/manifests/stable/persistent/minio/risingwave.yaml
@@ -193,6 +193,15 @@ spec:
       nodeGroups:
       - replicas: 1
         name: ''
+        template:
+          spec:
+            resources:
+              limits:
+                cpu: 1
+                memory: 2Gi
+              requests:
+                cpu: 1
+                memory: 2Gi
     compactor:
       nodeGroups:
       - replicas: 1
@@ -201,12 +210,39 @@ spec:
       nodeGroups:
       - replicas: 1
         name: ''
+        template:
+          spec:
+            resources:
+              limits:
+                cpu: 1
+                memory: 2Gi
+              requests:
+                cpu: 1
+                memory: 2Gi
     compute:
       nodeGroups:
       - replicas: 1
         name: ''
+        template:
+          spec:
+            resources:
+              limits:
+                cpu: 8
+                memory: 32Gi # Memory limit will be set to `RW_TOTAL_MEMORY_BYTES`
+              requests:
+                cpu: 8
+                memory: 32Gi
     # Please comment out the following if you do not need connector node
     connector:
       nodeGroups:
       - replicas: 1
         name: ''
+        template:
+          spec:
+            resources:
+              limits:
+                cpu: 4
+                memory: 8Gi
+              requests:
+                cpu: 4
+                memory: 8Gi

--- a/docs/manifests/stable/persistent/s3/risingwave.yaml
+++ b/docs/manifests/stable/persistent/s3/risingwave.yaml
@@ -110,6 +110,15 @@ spec:
       nodeGroups:
       - replicas: 1
         name: ''
+        template:
+          spec:
+            resources:
+              limits:
+                cpu: 1
+                memory: 2Gi
+              requests:
+                cpu: 1
+                memory: 2Gi
     compactor:
       nodeGroups:
       - replicas: 1
@@ -118,12 +127,39 @@ spec:
       nodeGroups:
       - replicas: 1
         name: ''
+        template:
+          spec:
+            resources:
+              limits:
+                cpu: 1
+                memory: 2Gi
+              requests:
+                cpu: 1
+                memory: 2Gi
     compute:
       nodeGroups:
       - replicas: 1
         name: ''
+        template:
+          spec:
+            resources:
+              limits:
+                cpu: 8
+                memory: 32Gi # Memory limit will be set to `RW_TOTAL_MEMORY_BYTES`
+              requests:
+                cpu: 8
+                memory: 32Gi
     # Please comment out the following if you do not need connector node
     connector:
       nodeGroups:
       - replicas: 1
         name: ''
+        template:
+          spec:
+            resources:
+              limits:
+                cpu: 4
+                memory: 8Gi
+              requests:
+                cpu: 4
+                memory: 8Gi


### PR DESCRIPTION
## What's changed and what's your intention?

Update all YAML examples: add resource (cpu/memory) request & limit.

> If the memory limit is not set correctly, the cluster will OOM frequently, because every Pod thinks it has full memory to use.


## Checklist

- [ ] I have written the necessary docs and comments
- [ ] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
