### PR TITLE
chore: Bump up RisingWave to v1.3.0 in docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ the following command:
 ```shell
 kubectl get risingwave
 NAME         META STORE   STATE STORE   VERSION   RUNNING   AGE
-risingwave   Etcd         MinIO         v1.2.0    True      2m20s
+risingwave   Etcd         MinIO         v1.3.0    True      2m20s
 ```
 
 > Note: the `META STORE` column indicates the storage backend for the RisingWave metadata. The `STATE STORE` column


### PR DESCRIPTION
This follows the example PR #507. It only updates the docs. There are various yaml files which still refer to `v1.2.0`. Should we update these too?