### PR TITLE
docs: add emptydir for heap profiling

### DIFF
--- a/docs/manifests/risingwave/risingwave-aliyun-oss.yaml
+++ b/docs/manifests/risingwave/risingwave-aliyun-oss.yaml
@@ -29,6 +29,16 @@ spec:
         name: ""
         template:
           spec:
+            volumes:
+            - name: heap
+              emptyDir:
+                sizeLimit: 1Gi
+            volumeMounts:
+            - mountPath: /heap
+              name: heap
+            env:
+            - name: MALLOC_CONF
+              value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
             resources:
               limits:
                 cpu: 1
@@ -55,6 +65,16 @@ spec:
         name: ""
         template:
           spec:
+            volumes:
+            - name: heap
+              emptyDir:
+                sizeLimit: 1Gi
+            volumeMounts:
+            - mountPath: /heap
+              name: heap
+            env:
+            - name: MALLOC_CONF
+              value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
             resources:
               limits:
                 cpu: 8
@@ -68,6 +88,16 @@ spec:
         name: ""
         template:
           spec:
+            volumes:
+            - name: heap
+              emptyDir:
+                sizeLimit: 1Gi
+            volumeMounts:
+            - mountPath: /heap
+              name: heap
+            env:
+            - name: MALLOC_CONF
+              value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
             resources:
               limits:
                 cpu: 4

--- a/docs/manifests/risingwave/risingwave-aliyun-oss.yaml
+++ b/docs/manifests/risingwave/risingwave-aliyun-oss.yaml
@@ -39,6 +39,8 @@ spec:
             env:
             - name: MALLOC_CONF
               value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
+            - name: RW_HEAP_PROFILING_DIR
+              value: /heap
             resources:
               limits:
                 cpu: 1
@@ -75,6 +77,8 @@ spec:
             env:
             - name: MALLOC_CONF
               value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
+            - name: RW_HEAP_PROFILING_DIR
+              value: /heap
             resources:
               limits:
                 cpu: 8
@@ -98,6 +102,8 @@ spec:
             env:
             - name: MALLOC_CONF
               value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
+            - name: RW_HEAP_PROFILING_DIR
+              value: /heap
             resources:
               limits:
                 cpu: 4

--- a/docs/manifests/risingwave/risingwave-customize-config.yaml
+++ b/docs/manifests/risingwave/risingwave-customize-config.yaml
@@ -45,6 +45,16 @@ spec:
         name: ""
         template:
           spec:
+            volumes:
+            - name: heap
+              emptyDir:
+                sizeLimit: 1Gi
+            volumeMounts:
+            - mountPath: /heap
+              name: heap
+            env:
+            - name: MALLOC_CONF
+              value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
             resources:
               limits:
                 cpu: 1
@@ -71,6 +81,16 @@ spec:
         name: ""
         template:
           spec:
+            volumes:
+            - name: heap
+              emptyDir:
+                sizeLimit: 1Gi
+            volumeMounts:
+            - mountPath: /heap
+              name: heap
+            env:
+            - name: MALLOC_CONF
+              value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
             resources:
               limits:
                 cpu: 8
@@ -84,6 +104,16 @@ spec:
         name: ""
         template:
           spec:
+            volumes:
+            - name: heap
+              emptyDir:
+                sizeLimit: 1Gi
+            volumeMounts:
+            - mountPath: /heap
+              name: heap
+            env:
+            - name: MALLOC_CONF
+              value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
             resources:
               limits:
                 cpu: 4

--- a/docs/manifests/risingwave/risingwave-customize-config.yaml
+++ b/docs/manifests/risingwave/risingwave-customize-config.yaml
@@ -55,6 +55,8 @@ spec:
             env:
             - name: MALLOC_CONF
               value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
+            - name: RW_HEAP_PROFILING_DIR
+              value: /heap
             resources:
               limits:
                 cpu: 1
@@ -91,6 +93,8 @@ spec:
             env:
             - name: MALLOC_CONF
               value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
+            - name: RW_HEAP_PROFILING_DIR
+              value: /heap
             resources:
               limits:
                 cpu: 8
@@ -114,6 +118,8 @@ spec:
             env:
             - name: MALLOC_CONF
               value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
+            - name: RW_HEAP_PROFILING_DIR
+              value: /heap
             resources:
               limits:
                 cpu: 4

--- a/docs/manifests/risingwave/risingwave-etcd-auth.yaml
+++ b/docs/manifests/risingwave/risingwave-etcd-auth.yaml
@@ -105,6 +105,16 @@ spec:
         name: ""
         template:
           spec:
+            volumes:
+            - name: heap
+              emptyDir:
+                sizeLimit: 1Gi
+            volumeMounts:
+            - mountPath: /heap
+              name: heap
+            env:
+            - name: MALLOC_CONF
+              value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
             resources:
               limits:
                 cpu: 1
@@ -131,6 +141,16 @@ spec:
         name: ""
         template:
           spec:
+            volumes:
+            - name: heap
+              emptyDir:
+                sizeLimit: 1Gi
+            volumeMounts:
+            - mountPath: /heap
+              name: heap
+            env:
+            - name: MALLOC_CONF
+              value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
             resources:
               limits:
                 cpu: 8
@@ -144,6 +164,16 @@ spec:
         name: ""
         template:
           spec:
+            volumes:
+            - name: heap
+              emptyDir:
+                sizeLimit: 1Gi
+            volumeMounts:
+            - mountPath: /heap
+              name: heap
+            env:
+            - name: MALLOC_CONF
+              value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
             resources:
               limits:
                 cpu: 4

--- a/docs/manifests/risingwave/risingwave-etcd-auth.yaml
+++ b/docs/manifests/risingwave/risingwave-etcd-auth.yaml
@@ -115,6 +115,8 @@ spec:
             env:
             - name: MALLOC_CONF
               value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
+            - name: RW_HEAP_PROFILING_DIR
+              value: /heap
             resources:
               limits:
                 cpu: 1
@@ -151,6 +153,8 @@ spec:
             env:
             - name: MALLOC_CONF
               value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
+            - name: RW_HEAP_PROFILING_DIR
+              value: /heap
             resources:
               limits:
                 cpu: 8
@@ -174,6 +178,8 @@ spec:
             env:
             - name: MALLOC_CONF
               value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
+            - name: RW_HEAP_PROFILING_DIR
+              value: /heap
             resources:
               limits:
                 cpu: 4

--- a/docs/manifests/risingwave/risingwave-etcd-azure.yaml
+++ b/docs/manifests/risingwave/risingwave-etcd-azure.yaml
@@ -111,6 +111,8 @@ spec:
             env:
             - name: MALLOC_CONF
               value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
+            - name: RW_HEAP_PROFILING_DIR
+              value: /heap
             resources:
               limits:
                 cpu: 1
@@ -147,6 +149,8 @@ spec:
             env:
             - name: MALLOC_CONF
               value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
+            - name: RW_HEAP_PROFILING_DIR
+              value: /heap
             resources:
               limits:
                 cpu: 8
@@ -170,6 +174,8 @@ spec:
             env:
             - name: MALLOC_CONF
               value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
+            - name: RW_HEAP_PROFILING_DIR
+              value: /heap
             resources:
               limits:
                 cpu: 4

--- a/docs/manifests/risingwave/risingwave-etcd-azure.yaml
+++ b/docs/manifests/risingwave/risingwave-etcd-azure.yaml
@@ -101,6 +101,16 @@ spec:
         name: ""
         template:
           spec:
+            volumes:
+            - name: heap
+              emptyDir:
+                sizeLimit: 1Gi
+            volumeMounts:
+            - mountPath: /heap
+              name: heap
+            env:
+            - name: MALLOC_CONF
+              value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
             resources:
               limits:
                 cpu: 1
@@ -127,6 +137,16 @@ spec:
         name: ""
         template:
           spec:
+            volumes:
+            - name: heap
+              emptyDir:
+                sizeLimit: 1Gi
+            volumeMounts:
+            - mountPath: /heap
+              name: heap
+            env:
+            - name: MALLOC_CONF
+              value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
             resources:
               limits:
                 cpu: 8
@@ -140,6 +160,16 @@ spec:
         name: ""
         template:
           spec:
+            volumes:
+            - name: heap
+              emptyDir:
+                sizeLimit: 1Gi
+            volumeMounts:
+            - mountPath: /heap
+              name: heap
+            env:
+            - name: MALLOC_CONF
+              value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
             resources:
               limits:
                 cpu: 4

--- a/docs/manifests/risingwave/risingwave-etcd-hdfs.yaml
+++ b/docs/manifests/risingwave/risingwave-etcd-hdfs.yaml
@@ -404,6 +404,16 @@ spec:
           name: ""
           template:
             spec:
+              volumes:
+              - name: heap
+                emptyDir:
+                  sizeLimit: 1Gi
+              volumeMounts:
+              - mountPath: /heap
+                name: heap
+              env:
+              - name: MALLOC_CONF
+                value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
               resources:
                 limits:
                   cpu: 1
@@ -430,6 +440,16 @@ spec:
           name: ""
           template:
             spec:
+              volumes:
+              - name: heap
+                emptyDir:
+                  sizeLimit: 1Gi
+              volumeMounts:
+              - mountPath: /heap
+                name: heap
+              env:
+              - name: MALLOC_CONF
+                value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
               resources:
                 limits:
                   cpu: 8
@@ -443,6 +463,16 @@ spec:
           name: ""
           template:
             spec:
+              volumes:
+              - name: heap
+                emptyDir:
+                  sizeLimit: 1Gi
+              volumeMounts:
+              - mountPath: /heap
+                name: heap
+              env:
+              - name: MALLOC_CONF
+                value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
               resources:
                 limits:
                   cpu: 4

--- a/docs/manifests/risingwave/risingwave-etcd-minio.yaml
+++ b/docs/manifests/risingwave/risingwave-etcd-minio.yaml
@@ -162,6 +162,16 @@ spec:
         name: ""
         template:
           spec:
+            volumes:
+            - name: heap
+              emptyDir:
+                sizeLimit: 1Gi
+            volumeMounts:
+            - mountPath: /heap
+              name: heap
+            env:
+            - name: MALLOC_CONF
+              value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
             resources:
               limits:
                 cpu: 1
@@ -188,6 +198,16 @@ spec:
         name: ""
         template:
           spec:
+            volumes:
+            - name: heap
+              emptyDir:
+                sizeLimit: 1Gi
+            volumeMounts:
+            - mountPath: /heap
+              name: heap
+            env:
+            - name: MALLOC_CONF
+              value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
             resources:
               limits:
                 cpu: 8
@@ -201,6 +221,16 @@ spec:
         name: ""
         template:
           spec:
+            volumes:
+            - name: heap
+              emptyDir:
+                sizeLimit: 1Gi
+            volumeMounts:
+            - mountPath: /heap
+              name: heap
+            env:
+            - name: MALLOC_CONF
+              value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
             resources:
               limits:
                 cpu: 4

--- a/docs/manifests/risingwave/risingwave-etcd-minio.yaml
+++ b/docs/manifests/risingwave/risingwave-etcd-minio.yaml
@@ -172,6 +172,8 @@ spec:
             env:
             - name: MALLOC_CONF
               value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
+            - name: RW_HEAP_PROFILING_DIR
+              value: /heap
             resources:
               limits:
                 cpu: 1
@@ -208,6 +210,8 @@ spec:
             env:
             - name: MALLOC_CONF
               value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
+            - name: RW_HEAP_PROFILING_DIR
+              value: /heap
             resources:
               limits:
                 cpu: 8
@@ -231,6 +235,8 @@ spec:
             env:
             - name: MALLOC_CONF
               value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
+            - name: RW_HEAP_PROFILING_DIR
+              value: /heap
             resources:
               limits:
                 cpu: 4

--- a/docs/manifests/risingwave/risingwave-etcd-s3.yaml
+++ b/docs/manifests/risingwave/risingwave-etcd-s3.yaml
@@ -95,6 +95,16 @@ spec:
         name: ""
         template:
           spec:
+            volumes:
+            - name: heap
+              emptyDir:
+                sizeLimit: 1Gi
+            volumeMounts:
+            - mountPath: /heap
+              name: heap
+            env:
+            - name: MALLOC_CONF
+              value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
             resources:
               limits:
                 cpu: 1
@@ -121,6 +131,16 @@ spec:
         name: ""
         template:
           spec:
+            volumes:
+            - name: heap
+              emptyDir:
+                sizeLimit: 1Gi
+            volumeMounts:
+            - mountPath: /heap
+              name: heap
+            env:
+            - name: MALLOC_CONF
+              value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
             resources:
               limits:
                 cpu: 8
@@ -134,6 +154,16 @@ spec:
         name: ""
         template:
           spec:
+            volumes:
+            - name: heap
+              emptyDir:
+                sizeLimit: 1Gi
+            volumeMounts:
+            - mountPath: /heap
+              name: heap
+            env:
+            - name: MALLOC_CONF
+              value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
             resources:
               limits:
                 cpu: 4

--- a/docs/manifests/risingwave/risingwave-etcd-s3.yaml
+++ b/docs/manifests/risingwave/risingwave-etcd-s3.yaml
@@ -105,6 +105,8 @@ spec:
             env:
             - name: MALLOC_CONF
               value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
+            - name: RW_HEAP_PROFILING_DIR
+              value: /heap
             resources:
               limits:
                 cpu: 1
@@ -141,6 +143,9 @@ spec:
             env:
             - name: MALLOC_CONF
               value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
+            - name: RW_HEAP_PROFILING_DIR
+              value: /heap
+            - name: MALLOC_CONF
             resources:
               limits:
                 cpu: 8
@@ -164,6 +169,8 @@ spec:
             env:
             - name: MALLOC_CONF
               value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
+            - name: RW_HEAP_PROFILING_DIR
+              value: /heap
             resources:
               limits:
                 cpu: 4

--- a/docs/manifests/risingwave/risingwave-gcs.yaml
+++ b/docs/manifests/risingwave/risingwave-gcs.yaml
@@ -27,6 +27,16 @@ spec:
         name: ""
         template:
           spec:
+            volumes:
+            - name: heap
+              emptyDir:
+                sizeLimit: 1Gi
+            volumeMounts:
+            - mountPath: /heap
+              name: heap
+            env:
+            - name: MALLOC_CONF
+              value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
             resources:
               limits:
                 cpu: 1
@@ -53,6 +63,16 @@ spec:
         name: ""
         template:
           spec:
+            volumes:
+            - name: heap
+              emptyDir:
+                sizeLimit: 1Gi
+            volumeMounts:
+            - mountPath: /heap
+              name: heap
+            env:
+            - name: MALLOC_CONF
+              value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
             resources:
               limits:
                 cpu: 8
@@ -66,6 +86,16 @@ spec:
         name: ""
         template:
           spec:
+            volumes:
+            - name: heap
+              emptyDir:
+                sizeLimit: 1Gi
+            volumeMounts:
+            - mountPath: /heap
+              name: heap
+            env:
+            - name: MALLOC_CONF
+              value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
             resources:
               limits:
                 cpu: 4

--- a/docs/manifests/risingwave/risingwave-gcs.yaml
+++ b/docs/manifests/risingwave/risingwave-gcs.yaml
@@ -37,6 +37,8 @@ spec:
             env:
             - name: MALLOC_CONF
               value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
+            - name: RW_HEAP_PROFILING_DIR
+              value: /heap
             resources:
               limits:
                 cpu: 1
@@ -73,6 +75,8 @@ spec:
             env:
             - name: MALLOC_CONF
               value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
+            - name: RW_HEAP_PROFILING_DIR
+              value: /heap
             resources:
               limits:
                 cpu: 8
@@ -96,6 +100,8 @@ spec:
             env:
             - name: MALLOC_CONF
               value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
+            - name: RW_HEAP_PROFILING_DIR
+              value: /heap
             resources:
               limits:
                 cpu: 4

--- a/docs/manifests/risingwave/risingwave-hdfs.yaml
+++ b/docs/manifests/risingwave/risingwave-hdfs.yaml
@@ -331,6 +331,16 @@ spec:
           name: ""
           template:
             spec:
+              volumes:
+              - name: heap
+                emptyDir:
+                  sizeLimit: 1Gi
+              volumeMounts:
+              - mountPath: /heap
+                name: heap
+              env:
+              - name: MALLOC_CONF
+                value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
               resources:
                 limits:
                   cpu: 1
@@ -357,6 +367,16 @@ spec:
           name: ""
           template:
             spec:
+              volumes:
+              - name: heap
+                emptyDir:
+                  sizeLimit: 1Gi
+              volumeMounts:
+              - mountPath: /heap
+                name: heap
+              env:
+              - name: MALLOC_CONF
+                value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
               resources:
                 limits:
                   cpu: 8
@@ -370,6 +390,16 @@ spec:
           name: ""
           template:
             spec:
+              volumes:
+              - name: heap
+                emptyDir:
+                  sizeLimit: 1Gi
+              volumeMounts:
+              - mountPath: /heap
+                name: heap
+              env:
+              - name: MALLOC_CONF
+                value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
               resources:
                 limits:
                   cpu: 4

--- a/docs/manifests/risingwave/risingwave-s3-compatible.yaml
+++ b/docs/manifests/risingwave/risingwave-s3-compatible.yaml
@@ -28,6 +28,16 @@ spec:
         name: ""
         template:
           spec:
+            volumes:
+            - name: heap
+              emptyDir:
+                sizeLimit: 1Gi
+            volumeMounts:
+            - mountPath: /heap
+              name: heap
+            env:
+            - name: MALLOC_CONF
+              value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
             resources:
               limits:
                 cpu: 1
@@ -54,6 +64,16 @@ spec:
         name: ""
         template:
           spec:
+            volumes:
+            - name: heap
+              emptyDir:
+                sizeLimit: 1Gi
+            volumeMounts:
+            - mountPath: /heap
+              name: heap
+            env:
+            - name: MALLOC_CONF
+              value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
             resources:
               limits:
                 cpu: 8
@@ -67,6 +87,16 @@ spec:
         name: ""
         template:
           spec:
+            volumes:
+            - name: heap
+              emptyDir:
+                sizeLimit: 1Gi
+            volumeMounts:
+            - mountPath: /heap
+              name: heap
+            env:
+            - name: MALLOC_CONF
+              value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
             resources:
               limits:
                 cpu: 4

--- a/docs/manifests/risingwave/risingwave-s3-compatible.yaml
+++ b/docs/manifests/risingwave/risingwave-s3-compatible.yaml
@@ -38,6 +38,8 @@ spec:
             env:
             - name: MALLOC_CONF
               value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
+            - name: RW_HEAP_PROFILING_DIR
+              value: /heap
             resources:
               limits:
                 cpu: 1
@@ -74,6 +76,8 @@ spec:
             env:
             - name: MALLOC_CONF
               value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
+            - name: RW_HEAP_PROFILING_DIR
+              value: /heap
             resources:
               limits:
                 cpu: 8
@@ -97,6 +101,8 @@ spec:
             env:
             - name: MALLOC_CONF
               value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
+            - name: RW_HEAP_PROFILING_DIR
+              value: /heap
             resources:
               limits:
                 cpu: 4

--- a/docs/manifests/stable/persistent/minio/risingwave.yaml
+++ b/docs/manifests/stable/persistent/minio/risingwave.yaml
@@ -195,6 +195,16 @@ spec:
         name: ''
         template:
           spec:
+            volumes:
+            - name: heap
+              emptyDir:
+                sizeLimit: 1Gi
+            volumeMounts:
+            - mountPath: /heap
+              name: heap
+            env:
+            - name: MALLOC_CONF
+              value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
             resources:
               limits:
                 cpu: 1
@@ -206,6 +216,18 @@ spec:
       nodeGroups:
       - replicas: 1
         name: ''
+        template:
+          spec:
+            volumes:
+            - name: heap
+              emptyDir:
+                sizeLimit: 1Gi
+            volumeMounts:
+            - mountPath: /heap
+              name: heap
+            env:
+            - name: MALLOC_CONF
+              value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
     frontend:
       nodeGroups:
       - replicas: 1
@@ -225,6 +247,16 @@ spec:
         name: ''
         template:
           spec:
+            volumes:
+            - name: heap
+              emptyDir:
+                sizeLimit: 1Gi
+            volumeMounts:
+            - mountPath: /heap
+              name: heap
+            env:
+            - name: MALLOC_CONF
+              value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
             resources:
               limits:
                 cpu: 8

--- a/docs/manifests/stable/persistent/minio/risingwave.yaml
+++ b/docs/manifests/stable/persistent/minio/risingwave.yaml
@@ -205,6 +205,8 @@ spec:
             env:
             - name: MALLOC_CONF
               value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
+            - name: RW_HEAP_PROFILING_DIR
+              value: /heap
             resources:
               limits:
                 cpu: 1
@@ -228,6 +230,8 @@ spec:
             env:
             - name: MALLOC_CONF
               value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
+            - name: RW_HEAP_PROFILING_DIR
+              value: /heap
     frontend:
       nodeGroups:
       - replicas: 1
@@ -257,6 +261,8 @@ spec:
             env:
             - name: MALLOC_CONF
               value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
+            - name: RW_HEAP_PROFILING_DIR
+              value: /heap
             resources:
               limits:
                 cpu: 8

--- a/docs/manifests/stable/persistent/s3/risingwave.yaml
+++ b/docs/manifests/stable/persistent/s3/risingwave.yaml
@@ -122,6 +122,8 @@ spec:
             env:
             - name: MALLOC_CONF
               value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
+            - name: RW_HEAP_PROFILING_DIR
+              value: /heap
             resources:
               limits:
                 cpu: 1
@@ -145,6 +147,8 @@ spec:
             env:
             - name: MALLOC_CONF
               value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
+            - name: RW_HEAP_PROFILING_DIR
+              value: /heap
     frontend:
       nodeGroups:
       - replicas: 1
@@ -174,6 +178,8 @@ spec:
             env:
             - name: MALLOC_CONF
               value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
+            - name: RW_HEAP_PROFILING_DIR
+              value: /heap
             resources:
               limits:
                 cpu: 8

--- a/docs/manifests/stable/persistent/s3/risingwave.yaml
+++ b/docs/manifests/stable/persistent/s3/risingwave.yaml
@@ -112,6 +112,16 @@ spec:
         name: ''
         template:
           spec:
+            volumes:
+            - name: heap
+              emptyDir:
+                sizeLimit: 1Gi
+            volumeMounts:
+            - mountPath: /heap
+              name: heap
+            env:
+            - name: MALLOC_CONF
+              value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
             resources:
               limits:
                 cpu: 1
@@ -123,6 +133,18 @@ spec:
       nodeGroups:
       - replicas: 1
         name: ''
+        template:
+          spec:
+            volumes:
+            - name: heap
+              emptyDir:
+                sizeLimit: 1Gi
+            volumeMounts:
+            - mountPath: /heap
+              name: heap
+            env:
+            - name: MALLOC_CONF
+              value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
     frontend:
       nodeGroups:
       - replicas: 1
@@ -142,6 +164,16 @@ spec:
         name: ''
         template:
           spec:
+            volumes:
+            - name: heap
+              emptyDir:
+                sizeLimit: 1Gi
+            volumeMounts:
+            - mountPath: /heap
+              name: heap
+            env:
+            - name: MALLOC_CONF
+              value: prof:true,lg_prof_interval=-1,lg_prof_sample=20,prof_prefix:/heap/
             resources:
               limits:
                 cpu: 8


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Update most of the example manifests to enable the heap profiling on meta/frontend/compute nodes. Details:
  - `lg_prof_sample` are all 20
  - Files will be stored under `/heap`, which is backed by [emptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir).
  - Size limit is `1Gi`. Note it might or might not take effect. It depends on the local file system.
  
The following files were not changed:
- Memory based deployments
- Local disk state store (experimental)

## Checklist

- [ ] I have written the necessary docs and comments
- [ ] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
