### PR TITLE
Mark .spec.components.standalone.replicas as required. 

### DIFF
--- a/apis/risingwave/v1alpha1/risingwave_standalone_mode.go
+++ b/apis/risingwave/v1alpha1/risingwave_standalone_mode.go
@@ -39,7 +39,7 @@ type RisingWaveStandaloneComponent struct {
 	// +kubebuilder:default=1
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=1
-	Replicas int32 `json:"replicas,omitempty"`
+	Replicas int32 `json:"replicas"`
 
 	// Upgrade strategy for the components. By default, it is the same as the
 	// workload's default strategy that the component is deployed with.

--- a/config/crd/bases/risingwave.risingwavelabs.com_risingwaves.yaml
+++ b/config/crd/bases/risingwave.risingwavelabs.com_risingwaves.yaml
@@ -42678,6 +42678,8 @@ spec:
                               type: object
                           type: object
                         type: array
+                    required:
+                    - replicas
                     type: object
                 type: object
               configuration:

--- a/config/risingwave-operator-test.yaml
+++ b/config/risingwave-operator-test.yaml
@@ -42695,6 +42695,8 @@ spec:
                               type: object
                           type: object
                         type: array
+                    required:
+                    - replicas
                     type: object
                 type: object
               configuration:

--- a/config/risingwave-operator.yaml
+++ b/config/risingwave-operator.yaml
@@ -42695,6 +42695,8 @@ spec:
                               type: object
                           type: object
                         type: array
+                    required:
+                    - replicas
                     type: object
                 type: object
               configuration:


### PR DESCRIPTION
This fixes programatic patching on the field.

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- As title. Before the change, set the replicas to 0 and then with `MergeFrom` it will generate a patch like 

```json
{"spec":{"components":{"standalone":{"replicas":null}}}}
```

However, there's a default value `1` on the field so the patch actually does nothing. Remove the `omitempty` to avoid that. 

It's verified that after the change the patch looks like 

```json
{"spec":{"components":{"standalone":{"replicas":0}}}}
```

and it works well.

The change won't change the YAML compatibility since there's a default on the field.

## Checklist

- [ ] I have written the necessary docs and comments
- [ ] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
