### PR TITLE
fix: fix service type of standalone service, optimize for telemetry

### DIFF
--- a/pkg/factory/risingwave_object_factory_predicate_test.go
+++ b/pkg/factory/risingwave_object_factory_predicate_test.go
@@ -934,7 +934,8 @@ func servicesPredicates() []predicate[*corev1.Service, servicesTestCase] {
 		{
 			Name: "selector-equals",
 			Fn: func(obj *corev1.Service, testcase servicesTestCase) bool {
-				return hasServiceSelector(obj, podSelector(testcase.risingwave, testcase.component, nil))
+				selectorComponent := lo.If(testcase.selectorComponent == "", testcase.component).Else(testcase.selectorComponent)
+				return hasServiceSelector(obj, podSelector(testcase.risingwave, selectorComponent, nil))
 			},
 		},
 	}

--- a/pkg/factory/risingwave_object_factory_test.go
+++ b/pkg/factory/risingwave_object_factory_test.go
@@ -34,6 +34,7 @@ func Test_RisingWaveObjectFactory_Services(t *testing.T) {
 
 	for name, tc := range servicesTestCases() {
 		tc.risingwave = newTestRisingwave(func(r *risingwavev1alpha1.RisingWave) {
+			r.Spec.EnableStandaloneMode = ptr.To(tc.enableStandaloneMode)
 			r.Spec.FrontendServiceType = tc.globalServiceType
 		})
 
@@ -51,6 +52,8 @@ func Test_RisingWaveObjectFactory_Services(t *testing.T) {
 			svc = factory.NewCompactorService()
 		case consts.ComponentConnector:
 			svc = factory.NewConnectorService()
+		case consts.ComponentStandalone:
+			svc = factory.NewStandaloneService()
 		default:
 			t.Fatal("bad test")
 		}
@@ -83,6 +86,8 @@ func Test_RisingWaveObjectFactory_ServicesMeta(t *testing.T) {
 			svc = factory.NewCompactorService()
 		case consts.ComponentConnector:
 			svc = factory.NewConnectorService()
+		case consts.ComponentStandalone:
+			svc = factory.NewStandaloneService()
 		default:
 			t.Fatal("bad test")
 		}

--- a/pkg/factory/risingwave_object_factory_testcases_test.go
+++ b/pkg/factory/risingwave_object_factory_testcases_test.go
@@ -2694,10 +2694,12 @@ func computeAdvancedSTSTestCases() map[string]computeAdvancedSTSTestCase {
 
 type servicesTestCase struct {
 	baseTestCase
-	component         string
-	ports             map[string]int32
-	globalServiceType corev1.ServiceType
-	expectServiceType corev1.ServiceType
+	component            string
+	selectorComponent    string // Empty means equals to component.
+	ports                map[string]int32
+	enableStandaloneMode bool
+	globalServiceType    corev1.ServiceType
+	expectServiceType    corev1.ServiceType
 }
 
 func servicesTestCases() map[string]servicesTestCase {
@@ -2772,6 +2774,27 @@ func servicesTestCases() map[string]servicesTestCase {
 			component:         consts.ComponentConnector,
 			globalServiceType: corev1.ServiceTypeNodePort,
 			expectServiceType: corev1.ServiceTypeClusterIP,
+		},
+		"standalone-ports": {
+			component:            consts.ComponentStandalone,
+			enableStandaloneMode: true,
+			globalServiceType:    corev1.ServiceTypeNodePort,
+			expectServiceType:    corev1.ServiceTypeClusterIP,
+			ports: map[string]int32{
+				consts.PortService:   consts.FrontendServicePort,
+				consts.PortMetrics:   consts.MetaMetricsPort,
+				consts.PortDashboard: consts.MetaDashboardPort,
+			},
+		},
+		"standalone-frontend-ports": {
+			component:            consts.ComponentFrontend,
+			selectorComponent:    consts.ComponentStandalone,
+			enableStandaloneMode: true,
+			globalServiceType:    corev1.ServiceTypeNodePort,
+			expectServiceType:    corev1.ServiceTypeNodePort,
+			ports: map[string]int32{
+				consts.PortService: consts.FrontendServicePort,
+			},
 		},
 	}
 


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Set standalone service's type to `ClusterIP`.
- Remove expression to exclude standalone service as a target of ServiceMonitor.
- Disable `metrics` port on frontend service when RisingWave is in standalone mode so that ServiceMonitor won't leads to two identical jobs with different names.

## Checklist

- [ ] I have written the necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
