### PR TITLE
reenable stream frag exchange

### DIFF
--- a/monitoring/kube-prometheus-stack.yaml
+++ b/monitoring/kube-prometheus-stack.yaml
@@ -32,11 +32,6 @@ prometheus:
     - bearerTokenSecret:
         key: ""
       interval: 5s
-      metricRelabelings:
-        - action: drop
-          regex: stream_exchange_.+
-          sourceLabels:
-            - __name__
       port: metrics
       scrapeTimeout: 5s
     jobLabel: risingwave/risingwave


### PR DESCRIPTION
## What's changed and what's your intention?

The actor-level stream exchange metrics are already removed in the kernel. https://github.com/risingwavelabs/risingwave/issues/7362
The fragment-level metrics are small, just like other metrics on Grafana
![SCR-20240108-kfq](https://github.com/risingwavelabs/risingwave-operator/assets/5791930/32f02952-9533-426f-8f02-ee17b4bcdd56)

In the future, if any metrics are too large to be collected, stored, or shown, I'll ask the kernel to do it.

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [ ] I have written the necessary docs and comments
- [ ] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
