### PR TITLE
fix: RW_META_ADDR for meta node (for locally accessed from risectl)

### DIFF
--- a/pkg/factory/risingwave_object_factory.go
+++ b/pkg/factory/risingwave_object_factory.go
@@ -381,7 +381,7 @@ func (f *RisingWaveObjectFactory) envsForMetaArgs() []corev1.EnvVar {
 		// Env var for local risectl access.
 		{
 			Name:  envs.RWMetaAddr,
-			Value: fmt.Sprintf("127.0.0.1:%d", consts.MetaServicePort),
+			Value: fmt.Sprintf("http://127.0.0.1:%d", consts.MetaServicePort),
 		},
 		{
 			Name:  envs.RWConfigPath,
@@ -1584,7 +1584,7 @@ func (f *RisingWaveObjectFactory) setupStandaloneContainer(container *corev1.Con
 	// Env var for local risectl access.
 	container.Env = mergeListWhenKeyEquals(container.Env, corev1.EnvVar{
 		Name:  envs.RWMetaAddr,
-		Value: fmt.Sprintf("127.0.0.1:%d", consts.MetaServicePort),
+		Value: fmt.Sprintf("http://127.0.0.1:%d", consts.MetaServicePort),
 	}, func(a, b *corev1.EnvVar) bool { return a.Name == b.Name })
 
 	for _, env := range f.envsForStateStore() {


### PR DESCRIPTION
## What's changed and what's your intention?

Fix this problem:

```
root@benchmark-risingwave-meta-m-0:/risingwave/bin# ./risingwave ctl profile cpu --sleep 10
launching `ctl`
2024-01-26T05:40:23.291957186Z  INFO risingwave_ctl::common::meta_service: using meta addr from `RW_META_ADDR`: 127.0.0.1:5690
2024-01-26T05:40:23.292125303Z  INFO risingwave_rpc_client::meta_client: register meta client using strategy: 127.0.0.1:5690
2024-01-26T05:40:23.292539856Z  WARN risingwave_rpc_client::meta_client: Failed to connect to meta server 127.0.0.1:5690, trying again error=transport error: error trying to connect: invalid URL, scheme is missing
2024-01-26T05:40:23.332969831Z  WARN risingwave_rpc_client::meta_client: Failed to connect to meta server 127.0.0.1:5690, trying again error=transport error: error trying to connect: invalid URL, scheme is missing
2024-01-26T05:40:25.361432046Z  WARN risingwave_rpc_client::meta_client: Failed to connect to meta server 127.0.0.1:5690, trying again error=transport error: error trying to connect: invalid URL, scheme is missing
```

## Checklist

- [ ] I have written the necessary docs and comments
- [ ] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
