### PR TITLE
fix: wrong connection string for local disk object store

### DIFF
--- a/pkg/factory/risingwave_object_factory.go
+++ b/pkg/factory/risingwave_object_factory.go
@@ -157,7 +157,7 @@ func (f *RisingWaveObjectFactory) hummockConnectionStr() string {
 		return fmt.Sprintf("hummock+webhdfs://%s@%s", webhdfs.NameNode, webhdfs.Root)
 	case f.isStateStoreLocalDisk():
 		localDisk := stateStore.LocalDisk
-		return fmt.Sprintf("hummock+fs://@%s", localDisk.Root)
+		return fmt.Sprintf("hummock+fs://%s", localDisk.Root)
 	case f.isStateStoreHuaweiCloudOBS():
 		return fmt.Sprintf("hummock+obs://%s", stateStore.HuaweiCloudOBS.Bucket)
 	default:


### PR DESCRIPTION
After https://github.com/risingwavelabs/risingwave/pull/13915, local disk path is no longer hard coded, which exposes this bug.
