### PR TITLE
refactor: use ctrl runtime library func optimisation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,6 @@ module github.com/risingwavelabs/risingwave-operator
 
 go 1.21
 
-toolchain go1.21.5
 
 require (
 	github.com/distribution/reference v0.5.0

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/risingwavelabs/risingwave-operator
 
 go 1.21
 
+toolchain go1.21.5
 
 require (
 	github.com/distribution/reference v0.5.0


### PR DESCRIPTION
## What's changed and what's your intention?

This moves the pod filtering logic for the meta label from the reconciliation func to the controller, micro optimisation to not run unnecessary reconciliation on pods that do not need it.
Please explain **IN DETAIL** what the changes are in this PR and why they are needed:
- movement of pod filtering in meta role labeler from within the reconciliation, into the filter func of the controller builder

## Checklist

- [ x] I have written the necessary docs and comments
- [x ] I have added necessary unit tests and integration tests
