### PR TITLE
fix: remove the required mark for replicas field

### DIFF
--- a/apis/risingwave/v1alpha1/risingwave_node_group.go
+++ b/apis/risingwave/v1alpha1/risingwave_node_group.go
@@ -364,7 +364,6 @@ type RisingWaveNodeGroup struct {
 	Name string `json:"name"`
 
 	// Replicas of Pods in this group.
-	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Minimum=0
 	Replicas int32 `json:"replicas,omitempty"`
 

--- a/config/crd/bases/risingwave.risingwavelabs.com_risingwaves.yaml
+++ b/config/crd/bases/risingwave.risingwavelabs.com_risingwaves.yaml
@@ -6137,7 +6137,6 @@ spec:
                               type: array
                           required:
                           - name
-                          - replicas
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:
@@ -12198,7 +12197,6 @@ spec:
                               type: array
                           required:
                           - name
-                          - replicas
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:
@@ -18259,7 +18257,6 @@ spec:
                               type: array
                           required:
                           - name
-                          - replicas
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:
@@ -24320,7 +24317,6 @@ spec:
                               type: array
                           required:
                           - name
-                          - replicas
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:

--- a/config/risingwave-operator-test.yaml
+++ b/config/risingwave-operator-test.yaml
@@ -6154,7 +6154,6 @@ spec:
                               type: array
                           required:
                           - name
-                          - replicas
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:
@@ -12215,7 +12214,6 @@ spec:
                               type: array
                           required:
                           - name
-                          - replicas
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:
@@ -18276,7 +18274,6 @@ spec:
                               type: array
                           required:
                           - name
-                          - replicas
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:
@@ -24337,7 +24334,6 @@ spec:
                               type: array
                           required:
                           - name
-                          - replicas
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:

--- a/config/risingwave-operator.yaml
+++ b/config/risingwave-operator.yaml
@@ -6154,7 +6154,6 @@ spec:
                               type: array
                           required:
                           - name
-                          - replicas
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:
@@ -12215,7 +12214,6 @@ spec:
                               type: array
                           required:
                           - name
-                          - replicas
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:
@@ -18276,7 +18274,6 @@ spec:
                               type: array
                           required:
                           - name
-                          - replicas
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:
@@ -24337,7 +24334,6 @@ spec:
                               type: array
                           required:
                           - name
-                          - replicas
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- After bumping the `controller-gen` tool, the `+kubebuilder:validation:Required` mark takes effect correctly. And the field `replicas` under node group is incorrectly marked. Removing the mark resolves the following error when creating a `RisingWave` object if one of the `replicas` is set to 0:

```
The RisingWave "risingwave-in-memory" is invalid: spec.components.compute.nodeGroups[1].replicas: Required value
```

## Checklist

- [ ] I have written the necessary docs and comments
- [ ] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
