### PR TITLE
feat: turn the feature gate EnableForceUpdate on by default

### DIFF
--- a/pkg/features/feature_manager.go
+++ b/pkg/features/feature_manager.go
@@ -55,7 +55,7 @@ var (
 		{
 			Name:          EnableForceUpdate,
 			Description:   "This feature enables force resolve version conflict due to operator update",
-			DefaultEnable: false,
+			DefaultEnable: true,
 			Stage:         Beta,
 		},
 	}


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- The feature gate is used for handling conflicts when updating an k8s object, e.g., adding a PVC template in the meta/compute STS. The controller will delete the resource first and create it afterwards whenever there's a conflict.

## Checklist

- [ ] I have written the necessary docs and comments
- [ ] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
