### PR TITLE
YAML chart for using Postgres as metastore and local-disk as storage backend

### DIFF
--- a/docs/manifests/risingwave/risingwave-postgresql-local-disk.yaml
+++ b/docs/manifests/risingwave/risingwave-postgresql-local-disk.yaml
@@ -1,0 +1,126 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: risingwave-data
+  labels:
+    app: risingwave
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: risingwave.risingwavelabs.com/v1alpha1
+kind: RisingWave
+metadata:
+  name: risingwave
+spec:
+  image: risingwavelabs/risingwave:v2.0.1
+  metaStore:
+    postgresql:
+      credentials:
+        secretName: postgres-credentials
+        usernameKeyRef: username
+        passwordKeyRef: password
+      database: risingwave
+      host: postgres.example.com
+      port: 5432
+  stateStore:
+    localDisk:
+      root: /var/lib/risingwave/data
+  components:
+    meta:
+      nodeGroups:
+      - name: ""
+        replicas: 1
+        template:
+          spec:
+            volumes:
+            - name: risingwave-data
+              persistentVolumeClaim:
+                claimName: risingwave-data
+            volumeMounts:
+            - mountPath: /var/lib/risingwave/data
+              name: risingwave-data
+            resources:
+              limits:
+                cpu: 1
+                memory: 2Gi
+              requests:
+                cpu: 1
+                memory: 2Gi
+    frontend:
+      nodeGroups:
+      - name: ""
+        replicas: 1
+        template:
+          spec:
+            affinity:
+              podAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                - topologyKey: "kubernetes.io/hostname"
+                  labelSelector:
+                    matchLabels:
+                      risingwave/component: meta
+            resources:
+              limits:
+                cpu: 1
+                memory: 2Gi
+              requests:
+                cpu: 1
+                memory: 2Gi
+    compute:
+      nodeGroups:
+      - name: ""
+        replicas: 1
+        template:
+          spec:
+            volumes:
+            - name: risingwave-data
+              persistentVolumeClaim:
+                claimName: risingwave-data
+            volumeMounts:
+            - mountPath: /var/lib/risingwave/data
+              name: risingwave-data
+            affinity:
+              podAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                - topologyKey: "kubernetes.io/hostname"
+                  labelSelector:
+                    matchLabels:
+                      risingwave/component: meta
+            resources:
+              limits:
+                cpu: 8
+                memory: 32Gi # Memory limit will be set to `RW_TOTAL_MEMORY_BYTES`
+              requests:
+                cpu: 8
+                memory: 32Gi
+    compactor:
+      nodeGroups:
+      - name: ""
+        replicas: 1
+        template:
+          spec:
+            volumes:
+            - name: risingwave-data
+              persistentVolumeClaim:
+                claimName: risingwave-data
+            volumeMounts:
+            - mountPath: /var/lib/risingwave/data
+              name: risingwave-data
+            affinity:
+              podAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                - topologyKey: "kubernetes.io/hostname"
+                  labelSelector:
+                    matchLabels:
+                      risingwave/component: meta
+            resources:
+              limits:
+                cpu: 4
+                memory: 8Gi
+              requests:
+                cpu: 4
+                memory: 8Gi


### PR DESCRIPTION
## What's changed and what's your intention?

Added a new YAML file that has postgres as the metastore, but is otherwise similar to `risingwave-etcd-local-disk.yaml`

## Checklist

- [X] I have written the necessary docs and comments
- [X] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
