### PR TITLE
feat: enforce recreating (force updating) objects when operator versi…

### DIFF
--- a/pkg/manager/risingwave_controller_manager_impl.go
+++ b/pkg/manager/risingwave_controller_manager_impl.go
@@ -802,8 +802,11 @@ func (mgr *risingWaveControllerManagerImpl) syncObject(ctx context.Context, obj 
 		if !apierrors.IsInvalid(err) {
 			return err
 		}
-		if !mgr.forceUpdateEnabled ||
-			obj.GetLabels()[consts.LabelRisingWaveOperatorVersion] == newObj.GetLabels()[consts.LabelRisingWaveOperatorVersion] {
+
+		operatorVersionUnchanged := obj.GetLabels()[consts.LabelRisingWaveOperatorVersion] == newObj.GetLabels()[consts.LabelRisingWaveOperatorVersion]
+		// When operator isn't upgraded and force update isn't enabled, return the error. Otherwise, delete and create
+		// to avoid inconsistent state.
+		if !mgr.forceUpdateEnabled && operatorVersionUnchanged {
 			return err
 		}
 		if err := mgr.client.Delete(ctx, obj); err != nil {


### PR DESCRIPTION
…on changes

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Before the change, the `EnableForceUpdate` feature gate won't work even if there's a conflict when the object is created by the same version of operator. Though the feature was intended to address inconsistency after upgrading operator, it's now getting confusing as https://github.com/risingwavelabs/risingwave-operator/pull/727 is merged.
- The PR changes the behaviour to let operator automatically address inconsistency problems on operator version changes, and do force updates when the feature gate is on.

## Checklist

- [ ] I have written the necessary docs and comments
- [ ] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
