### PR TITLE
feat: Support resource groups

### DIFF
--- a/pkg/factory/envs/risingwave.go
+++ b/pkg/factory/envs/risingwave.go
@@ -54,6 +54,7 @@ const (
 	RWLicenseKey               = "RW_LICENSE_KEY"
 	RWLicenseKeyPath           = "RW_LICENSE_KEY_PATH"
 	RWSecretStorePrivateKeyHex = "RW_SECRET_STORE_PRIVATE_KEY_HEX"
+	RWResourceGroup            = "RW_RESOURCE_GROUP"
 )
 
 // MinIO.

--- a/pkg/factory/risingwave_object_factory.go
+++ b/pkg/factory/risingwave_object_factory.go
@@ -1666,7 +1666,7 @@ func (f *RisingWaveObjectFactory) buildPodTemplateFromNodeGroup(component string
 	}
 
 	// set resource group in compute component.
-	if component == consts.ComponentCompute && nodeGroup.Name != "default" {
+	if component == consts.ComponentCompute && nodeGroup.Name != "" {
 		container := &podTemplate.Spec.Containers[0]
 		container.Env = append(container.Env, corev1.EnvVar{
 			Name:  envs.RWResourceGroup,

--- a/pkg/factory/risingwave_object_factory.go
+++ b/pkg/factory/risingwave_object_factory.go
@@ -1668,7 +1668,10 @@ func (f *RisingWaveObjectFactory) buildPodTemplateFromNodeGroup(component string
 	// set resource group in compute component.
 	if component == consts.ComponentCompute {
 		container := &podTemplate.Spec.Containers[0]
-		container.Args = append(container.Args, fmt.Sprintf("--resource-group=%s", nodeGroup.Name))
+		container.Env = append(container.Env, corev1.EnvVar{
+			Name:  envs.RWResourceGroup,
+			Value: nodeGroup.Name,
+		})
 	}
 
 	// Inject RisingWave's config volume.
@@ -1926,7 +1929,7 @@ func (f *RisingWaveObjectFactory) portsForComputeContainer() []corev1.ContainerP
 	}
 }
 
-func (f *RisingWaveObjectFactory) setupComputeContainer(_ *corev1.PodSpec, container *corev1.Container) {
+func (f *RisingWaveObjectFactory) setupComputeContainer(podSpec *corev1.PodSpec, container *corev1.Container) {
 	container.Name = "compute"
 	container.Args = []string{"compute-node"}
 

--- a/pkg/factory/risingwave_object_factory.go
+++ b/pkg/factory/risingwave_object_factory.go
@@ -1666,7 +1666,7 @@ func (f *RisingWaveObjectFactory) buildPodTemplateFromNodeGroup(component string
 	}
 
 	// set resource group in compute component.
-	if component == consts.ComponentCompute {
+	if component == consts.ComponentCompute && nodeGroup.Name != "default" {
 		container := &podTemplate.Spec.Containers[0]
 		container.Env = append(container.Env, corev1.EnvVar{
 			Name:  envs.RWResourceGroup,

--- a/pkg/factory/risingwave_object_factory_test.go
+++ b/pkg/factory/risingwave_object_factory_test.go
@@ -17,6 +17,7 @@
 package factory
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/samber/lo"
@@ -401,6 +402,29 @@ func TestRisingWaveObjectFactory_ComputeArgs(t *testing.T) {
 				if !listContainsByKey(envs, []corev1.EnvVar{expectEnv}, func(t *corev1.EnvVar) string { return t.Name }, deepEqual[corev1.EnvVar]) {
 					t.Errorf("Env not found or value not expected, expects \"%s\"", testutils.JSONMustPrettyPrint(expectEnv))
 				}
+			}
+		})
+		t.Run(name, func(t *testing.T) {
+			factory := NewRisingWaveObjectFactory(&risingwavev1alpha1.RisingWave{
+				Spec: risingwavev1alpha1.RisingWaveSpec{
+					StateStore: risingwavev1alpha1.RisingWaveStateStoreBackend{
+						Memory: ptr.To(true),
+					},
+				},
+			}, nil, "")
+			container := corev1.Container{}
+			rg := "resourceGroupName"
+			factory.setupComputeContainer(nil, &container, rg)
+			found := false
+			expected := fmt.Sprintf("--resource-group=%s", rg)
+			for _, arg := range container.Args {
+				if arg == expected {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("Expected \"%s\" in arguments, but go arguments %v", expected, container.Args)
 			}
 		})
 	}


### PR DESCRIPTION
## What's changed and what's your intention?

The resource group of a compute container should always be the same as the group name it is part of. 

https://linear.app/risingwave-labs/issue/CLOUD-3673/feature-resource-group-support-in-the-rw-operator


Very short demo: 

https://github.com/user-attachments/assets/b02b5202-60fa-427b-9019-9b17872cdda7




## Checklist

- [x] I have written the necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
