### PR TITLE
feat: add RW_SBC_ADDR

### DIFF
--- a/pkg/factory/envs/risingwave.go
+++ b/pkg/factory/envs/risingwave.go
@@ -55,6 +55,7 @@ const (
 	RWLicenseKeyPath           = "RW_LICENSE_KEY_PATH"
 	RWSecretStorePrivateKeyHex = "RW_SECRET_STORE_PRIVATE_KEY_HEX"
 	RWResourceGroup            = "RW_RESOURCE_GROUP"
+	RWSbcAddr                  = "RW_SBC_ADDR"
 )
 
 // MinIO.

--- a/pkg/factory/envs/risingwave.go
+++ b/pkg/factory/envs/risingwave.go
@@ -54,6 +54,7 @@ const (
 	RWLicenseKey               = "RW_LICENSE_KEY"
 	RWLicenseKeyPath           = "RW_LICENSE_KEY_PATH"
 	RWSecretStorePrivateKeyHex = "RW_SECRET_STORE_PRIVATE_KEY_HEX"
+	RWResourceGroup            = "RW_RESOURCE_GROUP"
 )
 
 // MinIO.

--- a/pkg/factory/risingwave_object_factory.go
+++ b/pkg/factory/risingwave_object_factory.go
@@ -1666,7 +1666,7 @@ func (f *RisingWaveObjectFactory) buildPodTemplateFromNodeGroup(component string
 	}
 
 	// set resource group in compute component.
-	if component == consts.ComponentCompute && nodeGroup.Name != "default" {
+	if component == consts.ComponentCompute && nodeGroup.Name != "" {
 		container := &podTemplate.Spec.Containers[0]
 		container.Env = append(container.Env, corev1.EnvVar{
 			Name:  envs.RWResourceGroup,

--- a/pkg/factory/risingwave_object_factory.go
+++ b/pkg/factory/risingwave_object_factory.go
@@ -1668,7 +1668,10 @@ func (f *RisingWaveObjectFactory) buildPodTemplateFromNodeGroup(component string
 	// set resource group in compute component.
 	if component == consts.ComponentCompute {
 		container := &podTemplate.Spec.Containers[0]
-		container.Args = append(container.Args, fmt.Sprintf("--resource-group=%s", nodeGroup.Name))
+		container.Env = append(container.Env, corev1.EnvVar{
+			Name:  envs.RWResourceGroup,
+			Value: nodeGroup.Name,
+		})
 	}
 
 	// Inject RisingWave's config volume.
@@ -1926,7 +1929,7 @@ func (f *RisingWaveObjectFactory) portsForComputeContainer() []corev1.ContainerP
 	}
 }
 
-func (f *RisingWaveObjectFactory) setupComputeContainer(_ *corev1.PodSpec, container *corev1.Container) {
+func (f *RisingWaveObjectFactory) setupComputeContainer(podSpec *corev1.PodSpec, container *corev1.Container) {
 	container.Name = "compute"
 	container.Args = []string{"compute-node"}
 

--- a/pkg/factory/risingwave_object_factory.go
+++ b/pkg/factory/risingwave_object_factory.go
@@ -1665,6 +1665,15 @@ func (f *RisingWaveObjectFactory) buildPodTemplateFromNodeGroup(component string
 		})
 	}
 
+	// set RWC endpoint for frontend.
+	if component == consts.ComponentFrontend {
+		container := &podTemplate.Spec.Containers[0]
+		container.Env = append(container.Env, corev1.EnvVar{
+			Name:  envs.RWSbcAddr,
+			Value: "rpc://serverless-backfill-controller:1298",
+		})
+	}
+
 	// set resource group in compute component.
 	if component == consts.ComponentCompute && nodeGroup.Name != "" {
 		container := &podTemplate.Spec.Containers[0]

--- a/pkg/factory/risingwave_object_factory.go
+++ b/pkg/factory/risingwave_object_factory.go
@@ -1666,7 +1666,7 @@ func (f *RisingWaveObjectFactory) buildPodTemplateFromNodeGroup(component string
 	}
 
 	// set resource group in compute component.
-	if component == consts.ComponentCompute {
+	if component == consts.ComponentCompute && nodeGroup.Name != "default" {
 		container := &podTemplate.Spec.Containers[0]
 		container.Env = append(container.Env, corev1.EnvVar{
 			Name:  envs.RWResourceGroup,

--- a/pkg/factory/risingwave_object_factory_test.go
+++ b/pkg/factory/risingwave_object_factory_test.go
@@ -17,6 +17,7 @@
 package factory
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/samber/lo"
@@ -401,6 +402,29 @@ func TestRisingWaveObjectFactory_ComputeArgs(t *testing.T) {
 				if !listContainsByKey(envs, []corev1.EnvVar{expectEnv}, func(t *corev1.EnvVar) string { return t.Name }, deepEqual[corev1.EnvVar]) {
 					t.Errorf("Env not found or value not expected, expects \"%s\"", testutils.JSONMustPrettyPrint(expectEnv))
 				}
+			}
+		})
+		t.Run(name, func(t *testing.T) {
+			factory := NewRisingWaveObjectFactory(&risingwavev1alpha1.RisingWave{
+				Spec: risingwavev1alpha1.RisingWaveSpec{
+					StateStore: risingwavev1alpha1.RisingWaveStateStoreBackend{
+						Memory: ptr.To(true),
+					},
+				},
+			}, nil, "")
+			container := corev1.Container{}
+			rg := "resourceGroupName"
+			factory.setupComputeContainer(nil, &container, rg)
+			found := false
+			expected := fmt.Sprintf("--resource-group=%s", rg)
+			for _, arg := range container.Args {
+				if arg == expected {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("Expected \"%s\" in arguments, but go arguments %v", expected, container.Args)
 			}
 		})
 	}


### PR DESCRIPTION
## What's changed and what's your intention?

We also need to set the SBC address. We can either do that in the operator or using the SBC. This would be the operator version. The downside is that we either have to hardcode the SBC address or we need to pass it to the operator. 

Alternative implementation using SBC: https://github.com/risingwavelabs/serverless-backfill-controller/pull/115 

## Checklist

- [ ] I have written the necessary docs and comments
- [ ] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
