### PR TITLE
fix: Change default group name

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -130,3 +130,8 @@ const (
 	CompactorServicePort int32 = 6660
 	CompactorMetricsPort int32 = 1260
 )
+
+// Resource group values.
+const (
+	DefaultResourceGroupName string = "default"
+)

--- a/pkg/factory/risingwave_object_factory.go
+++ b/pkg/factory/risingwave_object_factory.go
@@ -1666,7 +1666,7 @@ func (f *RisingWaveObjectFactory) buildPodTemplateFromNodeGroup(component string
 	}
 
 	// set resource group in compute component.
-	if component == consts.ComponentCompute && nodeGroup.Name != "" {
+	if component == consts.ComponentCompute && nodeGroup.Name != consts.DefaultResourceGroupName {
 		container := &podTemplate.Spec.Containers[0]
 		container.Env = append(container.Env, corev1.EnvVar{
 			Name:  envs.RWResourceGroup,


### PR DESCRIPTION
## What's changed and what's your intention?

Fix https://github.com/risingwavelabs/risingwave-operator/pull/816. Change default group name to `default`.

## Checklist

- [ ] I have written the necessary docs and comments
- [ ] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
