### PR TITLE
feat: add forcePathStyle field for S3 path-style

### DIFF
--- a/apis/risingwave/v1alpha1/risingwave_state_store_backend.go
+++ b/apis/risingwave/v1alpha1/risingwave_state_store_backend.go
@@ -111,6 +111,10 @@ type RisingWaveStateStoreBackendS3 struct {
 	// +optional
 	// +kubebuilder:validation:Pattern="^(?:https?://)?(?:[^/.\\s]+\\.)*(?:[^/\\s]+)*$"
 	Endpoint string `json:"endpoint,omitempty"`
+
+	// Enforce path style requests.
+	// +optional
+	ForcePathStyle bool `json:"forcePathStyle,omitempty"`
 }
 
 // RisingWaveGCSCredentials is the reference and keys selector to the GCS access credentials stored in a local secret.

--- a/config/crd/bases/risingwave.risingwavelabs.com_risingwaves.yaml
+++ b/config/crd/bases/risingwave.risingwavelabs.com_risingwaves.yaml
@@ -31041,6 +31041,9 @@ spec:
                           Both HTTP and HTTPS are allowed. The default scheme is HTTPS if not specified.
                         pattern: ^(?:https?://)?(?:[^/.\s]+\.)*(?:[^/\s]+)*$
                         type: string
+                      forcePathStyle:
+                        description: Enforce path style requests.
+                        type: boolean
                       region:
                         default: us-east-1
                         description: Region of AWS S3 service. Defaults to "us-east-1".

--- a/pkg/factory/envs/risingwave.go
+++ b/pkg/factory/envs/risingwave.go
@@ -87,6 +87,7 @@ const (
 	S3CompatibleAccessKeyID     = "AWS_ACCESS_KEY_ID"
 	S3CompatibleSecretAccessKey = "AWS_SECRET_ACCESS_KEY"
 	S3CompatibleEndpoint        = "RW_S3_ENDPOINT"
+	S3CompatibleForcePathStyle  = "RW_IS_FORCE_PATH_STYLE"
 )
 
 // Azure blob.

--- a/pkg/factory/risingwave_object_factory.go
+++ b/pkg/factory/risingwave_object_factory.go
@@ -1088,14 +1088,14 @@ func (f *RisingWaveObjectFactory) envsForS3() []corev1.EnvVar {
 			endpoint = "https://" + endpoint
 		}
 
-		return envsForS3Compatible(s3Spec.Region, endpoint, s3Spec.Bucket, s3Spec.RisingWaveS3Credentials)
+		return envsForS3Compatible(s3Spec.Region, endpoint, s3Spec.Bucket, s3Spec.RisingWaveS3Credentials, s3Spec.ForcePathStyle)
 	}
 
 	// AWS S3 mode.
 	return envsForAWSS3(s3Spec.Region, s3Spec.Bucket, s3Spec.RisingWaveS3Credentials)
 }
 
-func envsForS3Compatible(region, endpoint, bucket string, credentials risingwavev1alpha1.RisingWaveS3Credentials) []corev1.EnvVar {
+func envsForS3Compatible(region, endpoint, bucket string, credentials risingwavev1alpha1.RisingWaveS3Credentials, forcePathStyle bool) []corev1.EnvVar {
 	secretRef := corev1.LocalObjectReference{
 		Name: credentials.SecretName,
 	}
@@ -1152,6 +1152,10 @@ func envsForS3Compatible(region, endpoint, bucket string, credentials risingwave
 		{
 			Name:  envs.S3CompatibleEndpoint,
 			Value: endpoint,
+		},
+		{
+			Name:  envs.S3CompatibleForcePathStyle,
+			Value: strconv.FormatBool(forcePathStyle),
 		},
 	}
 }


### PR DESCRIPTION
Introduces a new `ForcePathStyle` field to the object storage spec. This allows users to explicitly enable path-style access for S3-compatible endpoints by setting the field to `true`.
