### PR TITLE
feat: support enabling webook listener

### DIFF
--- a/apis/risingwave/v1alpha1/risingwave_types.go
+++ b/apis/risingwave/v1alpha1/risingwave_types.go
@@ -114,6 +114,12 @@ type RisingWaveSpec struct {
 	// with their IP addresses. This is useful when one wants to avoid the DNS resolution overhead and latency.
 	EnableAdvertisingWithIP *bool `json:"enableAdvertisingWithIP,omitempty"`
 
+	// Flag to control whether to enable the webhook listener. If enabled, the webhook listener will be started
+	// in the frontend nodes to receive the webhook events from external systems, e.g., GitHub.
+	// +optional
+	// +kubebuilder:default=false
+	EnableWebhookListener *bool `json:"enableWebhookListener,omitempty"`
+
 	// Image for RisingWave component.
 	Image string `json:"image"`
 

--- a/apis/risingwave/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/risingwave/v1alpha1/zz_generated.deepcopy.go
@@ -1301,6 +1301,11 @@ func (in *RisingWaveSpec) DeepCopyInto(out *RisingWaveSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.EnableWebhookListener != nil {
+		in, out := &in.EnableWebhookListener, &out.EnableWebhookListener
+		*out = new(bool)
+		**out = **in
+	}
 	in.AdditionalFrontendServiceMetadata.DeepCopyInto(&out.AdditionalFrontendServiceMetadata)
 	in.MetaStore.DeepCopyInto(&out.MetaStore)
 	in.StateStore.DeepCopyInto(&out.StateStore)

--- a/config/crd/bases/risingwave.risingwavelabs.com_risingwaves.yaml
+++ b/config/crd/bases/risingwave.risingwavelabs.com_risingwaves.yaml
@@ -31648,6 +31648,12 @@ spec:
                   Flag to control whether to deploy in standalone mode or distributed mode. If standalone mode is used,
                   spec.components will be ignored. Standalone mode can be turned on/off dynamically.
                 type: boolean
+              enableWebhookListener:
+                default: false
+                description: |-
+                  Flag to control whether to enable the webhook listener. If enabled, the webhook listener will be started
+                  in the frontend nodes to receive the webhook events from external systems, e.g., GitHub.
+                type: boolean
               frontendServiceType:
                 default: ClusterIP
                 description: FrontendServiceType determines the service type of the

--- a/config/risingwave-operator-test.yaml
+++ b/config/risingwave-operator-test.yaml
@@ -31665,6 +31665,12 @@ spec:
                   Flag to control whether to deploy in standalone mode or distributed mode. If standalone mode is used,
                   spec.components will be ignored. Standalone mode can be turned on/off dynamically.
                 type: boolean
+              enableWebhookListener:
+                default: false
+                description: |-
+                  Flag to control whether to enable the webhook listener. If enabled, the webhook listener will be started
+                  in the frontend nodes to receive the webhook events from external systems, e.g., GitHub.
+                type: boolean
               frontendServiceType:
                 default: ClusterIP
                 description: FrontendServiceType determines the service type of the

--- a/config/risingwave-operator.yaml
+++ b/config/risingwave-operator.yaml
@@ -31665,6 +31665,12 @@ spec:
                   Flag to control whether to deploy in standalone mode or distributed mode. If standalone mode is used,
                   spec.components will be ignored. Standalone mode can be turned on/off dynamically.
                 type: boolean
+              enableWebhookListener:
+                default: false
+                description: |-
+                  Flag to control whether to enable the webhook listener. If enabled, the webhook listener will be started
+                  in the frontend nodes to receive the webhook events from external systems, e.g., GitHub.
+                type: boolean
               frontendServiceType:
                 default: ClusterIP
                 description: FrontendServiceType determines the service type of the

--- a/docs/general/api.md
+++ b/docs/general/api.md
@@ -628,6 +628,19 @@ with their IP addresses. This is useful when one wants to avoid the DNS resoluti
 </tr>
 <tr>
 <td>
+<code>enableWebhookListener</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Flag to control whether to enable the webhook listener. If enabled, the webhook listener will be started
+in the frontend nodes to receive the webhook events from external systems, e.g., GitHub.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>image</code><br/>
 <em>
 string
@@ -4757,6 +4770,19 @@ bool
 <td>
 <p>Flag to control whether to enable advertising with IP. If enabled, the meta and compute nodes will be advertised
 with their IP addresses. This is useful when one wants to avoid the DNS resolution overhead and latency.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>enableWebhookListener</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Flag to control whether to enable the webhook listener. If enabled, the webhook listener will be started
+in the frontend nodes to receive the webhook events from external systems, e.g., GitHub.</p>
 </td>
 </tr>
 <tr>

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -114,6 +114,7 @@ const (
 // Port names of components.
 const (
 	PortService   string = "service"
+	PortHTTP      string = "http"
 	PortMetrics   string = "metrics"
 	PortDashboard string = "dashboard"
 )
@@ -127,6 +128,7 @@ const (
 	ComputeMetricsPort   int32 = 1222
 	FrontendServicePort  int32 = 4567
 	FrontendMetricsPort  int32 = 8080
+	FrontendWebhookPort  int32 = 4560
 	CompactorServicePort int32 = 6660
 	CompactorMetricsPort int32 = 1260
 )

--- a/pkg/factory/envs/risingwave.go
+++ b/pkg/factory/envs/risingwave.go
@@ -55,6 +55,7 @@ const (
 	RWLicenseKeyPath           = "RW_LICENSE_KEY_PATH"
 	RWSecretStorePrivateKeyHex = "RW_SECRET_STORE_PRIVATE_KEY_HEX"
 	RWResourceGroup            = "RW_RESOURCE_GROUP"
+	RWWebhookListenAddr        = "RW_WEBHOOK_LISTEN_ADDR"
 )
 
 // MinIO.


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Add an option to enable the webhook listener of serving nodes. It defaults to listen on 0.0.0.0:4560.

## Checklist

- [ ] I have written the necessary docs and comments
- [ ] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
