### PR TITLE
fix(factory): use OrderedReady pod management for frontend StatefulSets

### DIFF
--- a/pkg/factory/risingwave_object_factory.go
+++ b/pkg/factory/risingwave_object_factory.go
@@ -1832,6 +1832,19 @@ func buildPersistentVolumeClaims(claims []risingwavev1alpha1.PersistentVolumeCla
 	return result
 }
 
+// buildPodManagementPolicy returns the PodManagementPolicy for a component's
+// StatefulSet. The frontend serves client SQL traffic, so it uses OrderedReady:
+// pods are rolled/scaled one at a time and each must become Ready before the
+// next is touched, keeping at least one replica serving (HA). Other components
+// use Parallel for faster startup and scaling.
+func buildPodManagementPolicy(component string) appsv1.PodManagementPolicyType {
+	if component == consts.ComponentFrontend {
+		return appsv1.OrderedReadyPodManagement
+	}
+
+	return appsv1.ParallelPodManagement
+}
+
 func (f *RisingWaveObjectFactory) newStatefulSet(component string, nodeGroup *risingwavev1alpha1.RisingWaveNodeGroup, template *corev1.PodTemplateSpec) *appsv1.StatefulSet {
 	return &appsv1.StatefulSet{
 		ObjectMeta: f.getObjectMetaForComponentGroupLevelResources(component, nodeGroup.Name, true),
@@ -1843,7 +1856,7 @@ func (f *RisingWaveObjectFactory) newStatefulSet(component string, nodeGroup *ri
 				MatchLabels: f.podLabelsOrSelectorsForComponentGroup(component, nodeGroup.Name),
 			},
 			Template:                             *template,
-			PodManagementPolicy:                  appsv1.ParallelPodManagement,
+			PodManagementPolicy:                  buildPodManagementPolicy(component),
 			MinReadySeconds:                      nodeGroup.MinReadySeconds,
 			VolumeClaimTemplates:                 buildPersistentVolumeClaims(nodeGroup.VolumeClaimTemplates),
 			PersistentVolumeClaimRetentionPolicy: nodeGroup.PersistentVolumeClaimRetentionPolicy,
@@ -1867,7 +1880,7 @@ func (f *RisingWaveObjectFactory) newAdvancedStatefulSet(component string, nodeG
 				MatchLabels: f.podLabelsOrSelectorsForComponentGroup(component, nodeGroup.Name),
 			},
 			Template:                             *template,
-			PodManagementPolicy:                  appsv1.ParallelPodManagement,
+			PodManagementPolicy:                  buildPodManagementPolicy(component),
 			VolumeClaimTemplates:                 buildPersistentVolumeClaims(nodeGroup.VolumeClaimTemplates),
 			PersistentVolumeClaimRetentionPolicy: convertAppsV1StatefulSetPersistentVolumeClaimRetentionPolicyToKruise(nodeGroup.PersistentVolumeClaimRetentionPolicy),
 		},

--- a/pkg/factory/risingwave_object_factory_test.go
+++ b/pkg/factory/risingwave_object_factory_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -372,6 +373,41 @@ func Test_RisingWaveObjectFactory_Frontend_AdvancedStatefulSets(t *testing.T) {
 			composeAssertions(predicates, t).assertTest(sts, tc)
 		})
 	}
+}
+
+// Test_RisingWaveObjectFactory_StatefulSet_PodManagementPolicy verifies that the
+// frontend StatefulSets use OrderedReady (so replicas are rolled/scaled one at a
+// time and stay available while serving), while the other components keep the
+// faster Parallel policy.
+func Test_RisingWaveObjectFactory_StatefulSet_PodManagementPolicy(t *testing.T) {
+	// The helper drives the decision for every component.
+	for component, expected := range map[string]appsv1.PodManagementPolicyType{
+		consts.ComponentFrontend:   appsv1.OrderedReadyPodManagement,
+		consts.ComponentMeta:       appsv1.ParallelPodManagement,
+		consts.ComponentCompute:    appsv1.ParallelPodManagement,
+		consts.ComponentCompactor:  appsv1.ParallelPodManagement,
+		consts.ComponentStandalone: appsv1.ParallelPodManagement,
+	} {
+		assert.Equal(t, expected, buildPodManagementPolicy(component), "unexpected policy for component %q", component)
+	}
+
+	risingwave := newTestRisingwave(func(r *risingwavev1alpha1.RisingWave) {
+		r.Spec.MetaStore.Memory = ptr.To(true)
+		r.Spec.StateStore.Memory = ptr.To(true)
+		r.Spec.Components.Frontend.NodeGroups = []risingwavev1alpha1.RisingWaveNodeGroup{{Replicas: 2}}
+		r.Spec.Components.Meta.NodeGroups = []risingwavev1alpha1.RisingWaveNodeGroup{{Replicas: 2}}
+		r.Spec.Components.Compute.NodeGroups = []risingwavev1alpha1.RisingWaveNodeGroup{{Replicas: 2}}
+	})
+
+	factory := NewRisingWaveObjectFactory(risingwave, testutils.Scheme, "")
+
+	// Frontend StatefulSets (both regular and OpenKruise) must be OrderedReady.
+	assert.Equal(t, appsv1.OrderedReadyPodManagement, factory.NewFrontendStatefulSet("").Spec.PodManagementPolicy)
+	assert.Equal(t, appsv1.OrderedReadyPodManagement, factory.NewFrontendAdvancedStatefulSet("").Spec.PodManagementPolicy)
+
+	// Other components keep Parallel.
+	assert.Equal(t, appsv1.ParallelPodManagement, factory.NewMetaStatefulSet("").Spec.PodManagementPolicy)
+	assert.Equal(t, appsv1.ParallelPodManagement, factory.NewComputeStatefulSet("").Spec.PodManagementPolicy)
 }
 
 func Test_RisingWaveObjectFactory_FrontendStatefulWorkloadsUseHeadlessService(t *testing.T) {


### PR DESCRIPTION
## What

The operator hardcodes `PodManagementPolicy: Parallel` for **every** StatefulSet it builds (`newStatefulSet` and the OpenKruise `newAdvancedStatefulSet` in `pkg/factory/risingwave_object_factory.go`). This applies to the frontend when it is deployed as a StatefulSet.

For the frontend — which serves client SQL traffic — `Parallel` lets replicas be created/scaled/recreated simultaneously. Worse, `maxUnavailable` on a StatefulSet rolling update only takes effect under `Parallel`, and the `Recreate` upgrade strategy sets `maxUnavailable: 100%`, so a rollout can take **all** frontend pods down at once → full serving outage.

## Change

Make the pod-management policy component-aware via a small helper:

- **frontend → `OrderedReady`**: pods are rolled/scaled/replaced one at a time, each must become Ready before the next is touched, so at least one replica keeps serving (HA).
- **meta / compute / compactor / standalone → `Parallel`** (unchanged): faster startup and scaling.

Both frontend StatefulSet paths are covered — the regular `NewFrontendStatefulSet` and the OpenKruise `NewFrontendAdvancedStatefulSet`.

## Trade-off

With `OrderedReady`, `maxUnavailable` no longer applies to frontend rollouts, so they proceed strictly one pod at a time (including the `Recreate` strategy). This is the intended HA-when-serving behavior; the only cost is slightly slower frontend rollouts/scaling.

## Migration / reconcile safety

`PodManagementPolicy` is immutable on a StatefulSet. This is handled by the operator's existing sync logic and does **not** cause a reconcile failure loop:

- **At upgrade (CR unchanged):** `isObjectSynced` keys on the RisingWave CR generation, so existing frontend StatefulSets are left untouched. No update attempt.
- **On the next spec change:** `syncObject`'s `Update` is rejected with `IsInvalid`; since the operator-version label changed, it falls through to delete + recreate the STS with `OrderedReady`. This incurs a one-time brief frontend restart.
- A stuck loop is only possible if the change ships without an operator-version bump **and** `EnableForceUpdate` is off (dev-only edge); the `EnableForceUpdate` feature gate is the escape hatch.

## Tests

Added `Test_RisingWaveObjectFactory_StatefulSet_PodManagementPolicy`, which asserts the helper's decision for all components and the resulting policy on the actual constructed frontend (regular + advanced) and meta/compute StatefulSets.

- `go build ./...` — clean
- `go vet ./pkg/factory/...` — clean
- `go test ./pkg/factory/...` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)