### PR TITLE
fix: extend compute startup probe window for recovery

### DIFF
--- a/pkg/factory/risingwave_object_factory.go
+++ b/pkg/factory/risingwave_object_factory.go
@@ -52,6 +52,9 @@ const (
 	risingwaveTLSVolume    = "risingwave-tls"
 	risingWaveConfigMapKey = "risingwave.toml"
 
+	defaultStartupProbeFailureThreshold = 12
+	computeStartupProbeFailureThreshold = 36
+
 	risingwaveExecutablePath    = "/risingwave/bin/risingwave"
 	risingwaveConfigMountPath   = "/risingwave/config"
 	risingwaveConfigFileName    = "risingwave.toml"
@@ -1552,7 +1555,7 @@ func basicSetupRisingWaveContainer(container *corev1.Container, component *risin
 		InitialDelaySeconds: 5,
 		PeriodSeconds:       5,
 		TimeoutSeconds:      5,
-		FailureThreshold:    12,
+		FailureThreshold:    defaultStartupProbeFailureThreshold,
 		ProbeHandler: corev1.ProbeHandler{
 			TCPSocket: &corev1.TCPSocketAction{
 				Port: intstr.FromString(consts.PortService),
@@ -2056,6 +2059,12 @@ func (f *RisingWaveObjectFactory) portsForComputeContainer() []corev1.ContainerP
 func (f *RisingWaveObjectFactory) setupComputeContainer(podSpec *corev1.PodSpec, container *corev1.Container) {
 	container.Name = "compute"
 	container.Args = []string{"compute-node"}
+
+	// Rebuilding the in-memory index for a persistent file cache can legitimately
+	// take longer than the default startup probe window.
+	if container.StartupProbe != nil {
+		container.StartupProbe.FailureThreshold = computeStartupProbeFailureThreshold
+	}
 
 	if f.isEmbeddedServingModeEnabled() {
 		container.Args = append(container.Args, "--role=streaming")

--- a/pkg/factory/risingwave_object_factory_test.go
+++ b/pkg/factory/risingwave_object_factory_test.go
@@ -115,6 +115,43 @@ func Test_RisingWaveObjectFactory_ConfigMaps(t *testing.T) {
 	}
 }
 
+func Test_BasicSetupRisingWaveContainer_StartupProbe(t *testing.T) {
+	container := &corev1.Container{}
+
+	basicSetupRisingWaveContainer(container, nil)
+
+	probe := container.StartupProbe
+	assert.NotNil(t, probe)
+	assert.Equal(t, int32(5), probe.InitialDelaySeconds)
+	assert.Equal(t, int32(5), probe.PeriodSeconds)
+	assert.Equal(t, int32(5), probe.TimeoutSeconds)
+	assert.Equal(t, int32(12), probe.FailureThreshold)
+	assert.NotNil(t, probe.TCPSocket)
+	assert.Equal(t, consts.PortService, probe.TCPSocket.Port.StrVal)
+}
+
+func Test_RisingWaveObjectFactory_Compute_StartupProbe(t *testing.T) {
+	risingwave := newTestRisingwave(func(r *risingwavev1alpha1.RisingWave) {
+		r.Spec.MetaStore.Memory = ptr.To(true)
+		r.Spec.StateStore.Memory = ptr.To(true)
+		r.Spec.Components.Compute.NodeGroups = []risingwavev1alpha1.RisingWaveNodeGroup{{
+			Name:     "",
+			Replicas: 1,
+		}}
+	})
+	factory := NewRisingWaveObjectFactory(risingwave, testutils.Scheme, "")
+
+	container := factory.NewComputeStatefulSet("").Spec.Template.Spec.Containers[0]
+	probe := container.StartupProbe
+	assert.NotNil(t, probe)
+	assert.Equal(t, int32(5), probe.InitialDelaySeconds)
+	assert.Equal(t, int32(5), probe.PeriodSeconds)
+	assert.Equal(t, int32(5), probe.TimeoutSeconds)
+	assert.Equal(t, int32(36), probe.FailureThreshold)
+	assert.NotNil(t, probe.TCPSocket)
+	assert.Equal(t, consts.PortService, probe.TCPSocket.Port.StrVal)
+}
+
 func Test_RisingWaveObjectFactory_Frontend_Deployments(t *testing.T) {
 	predicates := frontendDeploymentPredicates()
 


### PR DESCRIPTION
## What's changed and what's your intention?

RisingWave nodes currently get a startup probe with a roughly one-minute window (`initialDelaySeconds: 5`, `periodSeconds: 5`, `failureThreshold: 12`). Persistent disk-cache recovery on compute nodes can legitimately consume that entire window before the service port starts accepting connections. When that happens, kubelet restarts a healthy recovery process, and the pod can repeat the same recovery indefinitely.

This PR:

- keeps the shared startup probe default at `failureThreshold: 12` (roughly 1 minute) for meta, frontend, compactor, and standalone nodes;
- overrides only compute nodes to `failureThreshold: 36` (roughly 3 minutes);
- leaves startup probe timing/handler fields and all liveness/readiness probes unchanged;
- adds factory tests covering both the shared default and compute-specific startup probe configuration.

### Motivation

The incident that motivated this change followed this sequence:

1. Karpenter rescheduled three compute pods while retaining their persistent cache PVCs.
2. Each compute synchronously rebuilt its Foyer in-memory cache index from about 80.8 million on-disk entries.
3. Recovery took about 64.6 seconds, effectively consuming the existing startup probe budget before the service port opened.
4. Kubelet terminated each compute and the next process repeated recovery against the same PVC, leaving all compute workers in a permanent restart loop.

Foyer `Quiet` recovery is still synchronous; `Quiet` controls error handling rather than making recovery lazy or asynchronous. The recovery path scans blob indices, reconstructs entry addresses, deduplicates versions/tombstones, and populates the in-memory index before the service port is available.

### Why compute-specific and 3 minutes?

The current incident provides evidence only for compute file-cache recovery. Extending the shared default to 5 minutes would also delay detection of genuinely stuck startup for single-replica meta/frontend/standalone nodes, change alert timing, and potentially slow unrelated rollouts.

A roughly 3-minute compute window gives about 2.8x margin over the observed 64.6-second recovery while keeping other components at their existing behavior. This only delays restart when the process remains alive without opening the service port. A process that exits on a fatal error is still restarted immediately.

### Alternatives considered

- **Global 5-minute window:** smaller implementation, but affects every operator-managed component and can extend unrelated outages and rollouts. Rejected in favor of the narrower compute-only change.
- **Per-component or per-node-group configuration:** most flexible long-term design, especially for groups with different persistent-cache sizes. It requires a new CRD field, generated schema/deep-copy changes, Cloud manifest plumbing, and rollout compatibility tests, so it is intentionally not included in this narrow fix.
- **Disable cache recovery with `recover_mode = "none"`:** avoids startup recovery but forces a cold cache after every restart and increases object-store reads and post-restart performance variability. This is an operational workaround, not the default fix.
- **Expose startup health before recovery or recover lazily:** would let kubelet distinguish active recovery from a hung process, but requires a RisingWave/Foyer runtime change rather than an operator-only fix.

### Rollout impact

Only compute workload Pod templates change. Existing clusters may roll compute pods when a subsequent manifest reconciliation applies the new template; meta, frontend, compactor, and standalone Pod templates remain unchanged. This change is binary-version independent and requires no CRD or RisingWave configuration migration.

## Checklist

- [x] I have written the necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Validation

- `go test ./pkg/factory`
- `go test ./...`
- `go vet ./...`
- `make lint`

## Refer to a related PR or issue link (optional)

Follow-up to the startup probe introduced in #490.
