### PR TITLE
fix: grant events.k8s.io RBAC

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -20,13 +20,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - events
-  verbs:
-  - create
-  - patch
-- apiGroups:
-  - ""
-  resources:
   - services
   verbs:
   - create
@@ -69,6 +62,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 - apiGroups:
   - monitoring.coreos.com
   resources:

--- a/config/risingwave-operator-test.yaml
+++ b/config/risingwave-operator-test.yaml
@@ -40872,13 +40872,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - events
-  verbs:
-  - create
-  - patch
-- apiGroups:
-  - ""
-  resources:
   - services
   verbs:
   - create
@@ -40921,6 +40914,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 - apiGroups:
   - monitoring.coreos.com
   resources:

--- a/config/risingwave-operator.yaml
+++ b/config/risingwave-operator.yaml
@@ -40872,13 +40872,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - events
-  verbs:
-  - create
-  - patch
-- apiGroups:
-  - ""
-  resources:
   - services
   verbs:
   - create
@@ -40921,6 +40914,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 - apiGroups:
   - monitoring.coreos.com
   resources:

--- a/pkg/controller/risingwave_controller.go
+++ b/pkg/controller/risingwave_controller.go
@@ -120,7 +120,7 @@ const (
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;list;watch;create;delete;update;patch
-// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 
 // RisingWaveController is the controller for RisingWave.
 type RisingWaveController struct {

--- a/pkg/controller/risingwave_scale_view_controller.go
+++ b/pkg/controller/risingwave_scale_view_controller.go
@@ -56,7 +56,7 @@ type RisingWaveScaleViewController struct {
 // +kubebuilder:rbac:groups=risingwave.risingwavelabs.com,resources=risingwaves/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=risingwave.risingwavelabs.com,resources=risingwavescaleviews,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=risingwave.risingwavelabs.com,resources=risingwavescaleviews/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 
 // Reconcile implements the reconcile.Reconciler.
 func (c *RisingWaveScaleViewController) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {


### PR DESCRIPTION
## Summary

- grant the manager `create` and `patch` permissions for Events in the `events.k8s.io` API group
- update both Kubebuilder RBAC markers and regenerate the checked-in deployment manifests
- retain the core/v1 Events permission in the leader-election Role, which is used by controller-runtime's separate legacy leader-election recorder

## Rationale

The controller-runtime v0.23 migration in #979 replaced `GetEventRecorderFor` with `GetEventRecorder`. The new recorder writes `events.k8s.io/v1` Events, but the generated manager ClusterRole continued to authorize only core/v1 Events.

Reconciliation therefore succeeds, but lifecycle event writes such as `Initializing` and `Running` are rejected with an RBAC `forbidden` error. This change aligns the existing narrow Event permission with the API group actually used by the recorder; it does not broaden the resource or verb set.

Addresses #1059.

## Validation

- `make manifests generate-test-yaml`
- `go test ./...`
- semantic YAML validation of the manager and leader-election Event rules
- `git diff --check`

## Follow-up

The separately maintained `risingwavelabs/helm-charts` operator ClusterRole and its RBAC test need the corresponding `events.k8s.io` update. Its leader-election Role should continue using core/v1 Events.
