### PR TITLE
fix: probe both embedded serving ports

### DIFF
--- a/pkg/factory/risingwave_object_factory.go
+++ b/pkg/factory/risingwave_object_factory.go
@@ -1994,9 +1994,9 @@ func (f *RisingWaveObjectFactory) setupFrontendContainer(podSpec *corev1.PodSpec
 		container.ReadinessProbe.ProbeHandler = corev1.ProbeHandler{
 			Exec: &corev1.ExecAction{
 				Command: []string{
-					"/bin/sh",
+					"bash",
 					"-ec",
-					fmt.Sprintf("nc -z 127.0.0.1 %d\nnc -z 127.0.0.1 %d",
+					fmt.Sprintf("</dev/tcp/127.0.0.1/%d\n</dev/tcp/127.0.0.1/%d",
 						consts.FrontendServicePort, consts.ComputeServicePort),
 				},
 			},

--- a/pkg/factory/risingwave_object_factory.go
+++ b/pkg/factory/risingwave_object_factory.go
@@ -1991,6 +1991,16 @@ func (f *RisingWaveObjectFactory) setupFrontendContainer(podSpec *corev1.PodSpec
 			fmt.Sprintf("--frontend-opts=--listen-addr 0.0.0.0:%d --advertise-addr $(%s):%d",
 				consts.FrontendServicePort, envs.PodIP, consts.FrontendServicePort),
 		}
+		container.ReadinessProbe.ProbeHandler = corev1.ProbeHandler{
+			Exec: &corev1.ExecAction{
+				Command: []string{
+					"/bin/sh",
+					"-ec",
+					fmt.Sprintf("nc -z 127.0.0.1 %d\nnc -z 127.0.0.1 %d",
+						consts.FrontendServicePort, consts.ComputeServicePort),
+				},
+			},
+		}
 		container.Lifecycle = &corev1.Lifecycle{
 			PreStop: &corev1.LifecycleHandler{
 				Exec: &corev1.ExecAction{

--- a/pkg/factory/risingwave_object_factory_test.go
+++ b/pkg/factory/risingwave_object_factory_test.go
@@ -188,9 +188,9 @@ func Test_RisingWaveObjectFactory_Frontend_ReadinessProbe(t *testing.T) {
 				assert.Nil(t, probe.TCPSocket)
 				if assert.NotNil(t, probe.Exec) {
 					assert.Equal(t, []string{
-						"/bin/sh",
+						"bash",
 						"-ec",
-						"nc -z 127.0.0.1 4567\nnc -z 127.0.0.1 5688",
+						"</dev/tcp/127.0.0.1/4567\n</dev/tcp/127.0.0.1/5688",
 					}, probe.Exec.Command)
 				}
 			} else {

--- a/pkg/factory/risingwave_object_factory_test.go
+++ b/pkg/factory/risingwave_object_factory_test.go
@@ -152,6 +152,57 @@ func Test_RisingWaveObjectFactory_Compute_StartupProbe(t *testing.T) {
 	assert.Equal(t, consts.PortService, probe.TCPSocket.Port.StrVal)
 }
 
+func Test_RisingWaveObjectFactory_Frontend_ReadinessProbe(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		embeddedServing bool
+	}{
+		{
+			name:            "default",
+			embeddedServing: false,
+		},
+		{
+			name:            "embedded-serving",
+			embeddedServing: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			risingwave := newTestRisingwave(func(r *risingwavev1alpha1.RisingWave) {
+				r.Spec.MetaStore.Memory = ptr.To(true)
+				r.Spec.StateStore.Memory = ptr.To(true)
+				r.Spec.EnableEmbeddedServingMode = ptr.To(tc.embeddedServing)
+				r.Spec.Components.Frontend.NodeGroups = []risingwavev1alpha1.RisingWaveNodeGroup{{
+					Name:     "",
+					Replicas: 1,
+				}}
+			})
+			factory := NewRisingWaveObjectFactory(risingwave, testutils.Scheme, "")
+
+			container := factory.NewFrontendDeployment("").Spec.Template.Spec.Containers[0]
+			probe := container.ReadinessProbe
+			assert.NotNil(t, probe)
+			assert.Equal(t, int32(2), probe.InitialDelaySeconds)
+			assert.Equal(t, int32(10), probe.PeriodSeconds)
+
+			if tc.embeddedServing {
+				assert.Nil(t, probe.TCPSocket)
+				if assert.NotNil(t, probe.Exec) {
+					assert.Equal(t, []string{
+						"/bin/sh",
+						"-ec",
+						"nc -z 127.0.0.1 4567\nnc -z 127.0.0.1 5688",
+					}, probe.Exec.Command)
+				}
+			} else {
+				assert.Nil(t, probe.Exec)
+				if assert.NotNil(t, probe.TCPSocket) {
+					assert.Equal(t, consts.PortService, probe.TCPSocket.Port.StrVal)
+				}
+			}
+		})
+	}
+}
+
 func Test_RisingWaveObjectFactory_Frontend_Deployments(t *testing.T) {
 	predicates := frontendDeploymentPredicates()
 


### PR DESCRIPTION
## Summary

- check both the frontend and embedded compute listeners in the frontend readiness probe
- preserve the existing probe timing and non-embedded frontend behavior
- add unit coverage for embedded and standard frontend readiness probes

## Rationale

Embedded serving runs a serving compute node inside the frontend container, but the existing readiness probe only checks the frontend listener. This can mark the pod ready before the embedded compute listener is accepting connections. Requiring both ports prevents the frontend pod from becoming ready until its complete embedded-serving workload is available.

## Validation

- `go test ./pkg/factory`
