### PR TITLE
chore: upgrade kube-rbac-proxy to v0.22.1

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: quay.io/brancz/kube-rbac-proxy:v0.14.1
+        image: quay.io/brancz/kube-rbac-proxy:v0.22.1
         imagePullPolicy: IfNotPresent
         args:
         - "--secure-listen-address=0.0.0.0:8443"

--- a/config/risingwave-operator-test.yaml
+++ b/config/risingwave-operator-test.yaml
@@ -41174,7 +41174,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: quay.io/brancz/kube-rbac-proxy:v0.14.1
+        image: quay.io/brancz/kube-rbac-proxy:v0.22.1
         imagePullPolicy: IfNotPresent
         name: kube-rbac-proxy
         ports:

--- a/config/risingwave-operator.yaml
+++ b/config/risingwave-operator.yaml
@@ -41174,7 +41174,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: quay.io/brancz/kube-rbac-proxy:v0.14.1
+        image: quay.io/brancz/kube-rbac-proxy:v0.22.1
         imagePullPolicy: IfNotPresent
         name: kube-rbac-proxy
         ports:


### PR DESCRIPTION
## What

Bump the auth-proxy sidecar image from `quay.io/brancz/kube-rbac-proxy:v0.14.1` to `v0.22.1`.

Updated in the kustomize source patch and the two generated manifests:
- `config/default/manager_auth_proxy_patch.yaml`
- `config/risingwave-operator.yaml`
- `config/risingwave-operator-test.yaml`

## Why

Keep the metrics auth-proxy sidecar current. `v0.22.1` is confirmed available on `quay.io/brancz/kube-rbac-proxy` (multi-arch: amd64/arm64/arm/ppc64le/s390x), so no registry change is required.

## Testing

Verified end-to-end on a local OrbStack cluster (rolling the sidecar to `v0.22.1` on the live operator deployment):

- Pod rolled out cleanly, **Running 2/2**; sidecar image digest matches the quay.io `v0.22.1` manifest.
- Proxy logs: `Listening securely on 0.0.0.0:8443`; manager reconciling normally.
- Anonymous request to `/metrics` → **HTTP 401** (rejected).
- Authorized request (SA bound to `metrics-reader`) → **HTTP 200** with Prometheus metrics.
- Proxy performed `TokenReview` + `SubjectAccessReview` against the API server as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)